### PR TITLE
V5.1 [REV] Modify the  Bug 810

### DIFF
--- a/src/common/router.js
+++ b/src/common/router.js
@@ -184,7 +184,7 @@ export const getRouterData = (app) => {
     "/team/:team/region/:region/exception/500": {
       component: dynamicWrapper(app, [], () => import("../routes/Exception/500")),
     },
-    '/team/:team/region/:region/gateway/control': {
+    '/team/:team/region/:region/gateway/control/:types?/:isopen?': {
       component: dynamicWrapper(app, ["gateWay",'appControl'], () => import('../routes/GateWay/control')),
     },
     '/team/:team/region/:region/gateway/license': {

--- a/src/components/AddDomain/index.js
+++ b/src/components/AddDomain/index.js
@@ -1,5 +1,7 @@
 import React, { PureComponent } from "react";
 import { Form, Select, Modal, Input, Alert } from "antd";
+import { Link } from "dva/router";
+import globalUtil from '../../utils/global';
 
 const FormItem = Form.Item;
 const Option = Select.Option;
@@ -129,6 +131,19 @@ export default class AddDomain extends PureComponent {
               </a>
             </p>
           </FormItem>}
+
+          <div>
+          如果需要设置更多路由策略参数 ：
+          <Link to={`/team/${globalUtil.getCurrTeamName()}/region/${globalUtil.getCurrRegionName()}/gateway/control/http/true`} style={{
+                            wordBreak: "break-all",
+                            wordWrap: "break-word",
+                            color: "#1890ff"
+                        }}>
+                           点击进入访问策略设置
+                        </Link>
+
+
+          </div>
         </Form>
       </Modal>
     );

--- a/src/components/AppCreateSetting/index.js
+++ b/src/components/AppCreateSetting/index.js
@@ -745,7 +745,23 @@ class JAVA extends PureComponent {
         {
           (languageType == "java-war" || languageType == "Java-war") &&
           <div>
-
+            <Form.Item {...formItemLayout} label="开启清除构建缓存">
+              {getFieldDecorator('NO_CACHE', {
+                initialValue: ""
+              })(
+                <Radio onClick={() => { this.handleRadio("NO_CACHE") }} checked={this.state.NO_CACHE} ></Radio>
+              )}
+            </Form.Item>
+            <Form.Item {...formItemLayout} label="选择JDK版本">
+              {getFieldDecorator('RUNTIMES', {
+                initialValue: (runtimeInfo && runtimeInfo.BUILD_RUNTIMES) ? "OpenJDK" : (runtimeInfo && runtimeInfo.BUILD_ENABLE_ORACLEJDK) ? "Jdk" : "OpenJDK"
+              })(
+                <RadioGroup className={styles.ant_radio_disabled} onChange={this.onRadioGroupChange}>
+                  <Radio value='OpenJDK'>OpenJDK</Radio>
+                  <Radio value='Jdk'>OracleJDK</Radio>
+                </RadioGroup>
+              )}
+            </Form.Item>
             <Form.Item {...formItemLayout} label="选择JDK版本">
               {getFieldDecorator('RUNTIMES', {
                 initialValue: (runtimeInfo && runtimeInfo.BUILD_RUNTIMES) ? "OpenJDK" : (runtimeInfo && runtimeInfo.BUILD_ENABLE_ORACLEJDK) ? "Jdk" : "OpenJDK"

--- a/src/components/DrawerForm/index.js
+++ b/src/components/DrawerForm/index.js
@@ -42,7 +42,8 @@ class DrawerForm extends PureComponent {
             group_name: "",
             descriptionVisible: false,
             rule_extensions_visible: false,
-            isPerform: true
+            isPerform: true,
+            routingConfiguration: false
         }
     }
     componentWillMount() {
@@ -162,17 +163,23 @@ class DrawerForm extends PureComponent {
             this.setState({ rule_extensions_visible: true })
         }
     }
+
+    handleRoutingConfiguration = ()=>{
+        this.setState({
+            routingConfiguration:!this.state.routingConfiguration 
+        })
+    }
     render() {
         const { onClose, onOk, groups, editInfo, addHttpStrategyLoading, editHttpStrategyLoading } = this.props;
         const { getFieldDecorator } = this.props.form;
         const formItemLayout = {
             labelCol: {
-                xs: { span: 24 },
-                sm: { span: 4 }
+                xs: { span: 5 },
+                sm: { span: 5 }
             },
             wrapperCol: {
-                xs: { span: 24 },
-                sm: { span: 18 }
+                xs: { span: 19 },
+                sm: { span: 19 }
             }
         };
         // const currentGroup = editInfo ? editInfo.g_id : groups.lenth > 0 ? groups[0].group_id : null;
@@ -191,6 +198,7 @@ class DrawerForm extends PureComponent {
         const currentRegion = region.filter((item) => {
             return item.team_region_name == globalUtil.getCurrRegionName();
         })
+        const { routingConfiguration } = this.state;
         return (
             <div>
                 <Drawer
@@ -207,6 +215,7 @@ class DrawerForm extends PureComponent {
                     }}
                 >
                     <Form >
+                        <h3 style={{ borderBottom: "1px solid #BBBBBB",marginBottom:"10px" }}>路由规则</h3>
                         <FormItem
                             {...formItemLayout}
                             label="域名"
@@ -231,7 +240,7 @@ class DrawerForm extends PureComponent {
                         </FormItem>
                         <FormItem
                             {...formItemLayout}
-                            label="Path"
+                            label="Location"
                         >
                             {getFieldDecorator('domain_path', {
                                 rules: [
@@ -249,45 +258,80 @@ class DrawerForm extends PureComponent {
                                 <Input placeholder="/" />
                             )}
                         </FormItem>
-                        <FormItem
-                            {...formItemLayout}
-                            label="请求头"
-                        >
-                            {getFieldDecorator("domain_heander", { initialValue: editInfo.domain_heander })(<DAinput />)}
-                        </FormItem>
-                        <FormItem
-                            {...formItemLayout}
-                            label="Cookie"
-                        >
-                            {getFieldDecorator("domain_cookie", { initialValue: editInfo.domain_cookie })(<DAinput />)}
-                        </FormItem>
-                        <FormItem
-                            {...formItemLayout}
-                            label="权重"
-                        >
-                            {getFieldDecorator("the_weight", { initialValue: editInfo.the_weight || 100 })(
-                                <InputNumber min={1} max={100} style={{ width: "100%" }} />
-                            )}
-                        </FormItem>
-                        {this.state.licenseList && <FormItem
-                            {...formItemLayout}
-                            label="绑定证书"
-                            style={{ zIndex: 999 }}
-                        >
-                            {getFieldDecorator('certificate_id', { initialValue: editInfo.certificate_id })(
-                                <Select placeholder="请绑定证书" onSelect={this.handeCertificateSelect}>
-                                    {this.state.licenseList && this.state.licenseList.length > 0 && <Option value={""} key={99}>不绑定</Option>}
-                                    {
-                                        (this.state.licenseList).map((license, index) => {
-                                            return <Option value={license.id} key={index}>{license.alias}</Option>
-                                        })
-                                    }
-                                    {/* {this.state.licenseList.length > 0 ? (this.state.licenseList).map((license, index) => {
+
+                        {!routingConfiguration && <div>
+                            <p style={{ textAlign: "center" }}>更多高级路由参数<br></br><Icon type="down" onClick={this.handleRoutingConfiguration}/></p>
+                        </div>}
+
+                        {routingConfiguration && <div>
+                            <FormItem
+                                {...formItemLayout}
+                                label="请求头"
+                            >
+                                {getFieldDecorator("domain_heander", { initialValue: editInfo.domain_heander })(<DAinput />)}
+                            </FormItem>
+                            <FormItem
+                                {...formItemLayout}
+                                label="Cookie"
+                            >
+                                {getFieldDecorator("domain_cookie", { initialValue: editInfo.domain_cookie })(<DAinput />)}
+                            </FormItem>
+                            <FormItem
+                                {...formItemLayout}
+                                label="权重"
+                            >
+                                {getFieldDecorator("the_weight", { initialValue: editInfo.the_weight || 100 })(
+                                    <InputNumber min={1} max={100} style={{ width: "100%" }} />
+                                )}
+                            </FormItem>
+                            {this.state.licenseList && <FormItem
+                                {...formItemLayout}
+                                label="HTTPs证书"
+                                style={{ zIndex: 999 }}
+                            >
+                                {getFieldDecorator('certificate_id', { initialValue: editInfo.certificate_id })(
+                                    <Select placeholder="请绑定证书" onSelect={this.handeCertificateSelect}>
+                                        {this.state.licenseList && this.state.licenseList.length > 0 && <Option value={""} key={99}>不绑定</Option>}
+                                        {
+                                            (this.state.licenseList).map((license, index) => {
+                                                return <Option value={license.id} key={index}>{license.alias}</Option>
+                                            })
+                                        }
+                                        {/* {this.state.licenseList.length > 0 ? (this.state.licenseList).map((license, index) => {
                                         return <Option value={license.id.toString()} key={index}>{license.alias}</Option>
                                     }) : <Option value={editInfo.certificate_id} key={editInfo.certificate_id}>{editInfo.certificate_name}</Option>} */}
-                                </Select>
-                            )}
-                        </FormItem>}
+                                    </Select>
+                                )}
+                            </FormItem>}
+                            <FormItem
+                                {...formItemLayout}
+                                label="扩展功能"
+                            >
+                                {(this.state.rule_extensions_visible || (editInfo.certificate_id && rule_http)) && getFieldDecorator("rule_extensions_http", { initialValue: [rule_http] })(
+                                    <Checkbox.Group>
+                                        <Row>
+                                            <Col span={24}>
+                                                <Checkbox value="httptohttps">HTTP Rewrite HTTPs</Checkbox>
+                                            </Col>
+                                        </Row>
+                                    </Checkbox.Group>
+                                )}
+                                <FormItem>
+                                    {getFieldDecorator("rule_extensions_round", { initialValue: rule_round || 'round-robin' })(
+                                        <Select placeholder="请选择负载均衡类型">
+                                            <Option value="round-robin">轮询</Option>
+                                            {/* <Option value="random">random</Option>
+                                    <Option value="consistence-hash">consistence-hash</Option> */}
+                                        </Select>
+                                    )}
+                                </FormItem>
+                            </FormItem>
+
+                            <div style={{ textAlign: "center" }}><Icon type="up" onClick={this.handleRoutingConfiguration}/></div>
+
+                        </div>
+                        }
+                        <h3 style={{ borderBottom: "1px solid #BBBBBB",marginBottom:"10px"  }}>访问目标</h3>
                         <FormItem
                             {...formItemLayout}
                             label="应用(组)"
@@ -313,7 +357,7 @@ class DrawerForm extends PureComponent {
                         >
                             {getFieldDecorator('service_id', {
                                 rules: [{ required: true, message: '请选择' }],
-                                initialValue: editInfo && editInfo.service_id ? editInfo.service_id : this.state.serviceComponentList && this.state.serviceComponentList.length > 0 ? this.state.serviceComponentList[0].service_id : "",
+                                initialValue: editInfo && editInfo.service_id ? editInfo.service_id : this.state.serviceComponentList && this.state.serviceComponentList.length > 0 ? this.state.serviceComponentList[0].service_id : undefined,
                             })(
                                 <Select placeholder="请选择服务组件" onChange={this.handlePorts} >
                                     {
@@ -328,10 +372,10 @@ class DrawerForm extends PureComponent {
                         <FormItem
                             {...formItemLayout}
                             label="端口号"
-                            style={{ zIndex: 999 }}
+                            style={{ zIndex: 999,marginBottom:"150px" }}
                         >
                             {getFieldDecorator('container_port', {
-                                initialValue: editInfo && editInfo.container_port ? editInfo.container_port : this.state.portList && this.state.portList.length > 0 ? this.state.portList[0].container_port : "",
+                                initialValue: editInfo && editInfo.container_port ? editInfo.container_port : this.state.portList && this.state.portList.length > 0 ? this.state.portList[0].container_port : undefined,
                                 rules: [{ required: true, message: '请选择端口号' }],
                             })(
                                 <Select placeholder="请选择端口号">
@@ -343,29 +387,7 @@ class DrawerForm extends PureComponent {
                                 </Select>
                             )}
                         </FormItem>
-                        <FormItem
-                            {...formItemLayout}
-                            label="扩展功能"
-                        >
-                            {(this.state.rule_extensions_visible || (editInfo.certificate_id && rule_http)) && getFieldDecorator("rule_extensions_http", { initialValue: [rule_http] })(
-                                <Checkbox.Group>
-                                    <Row>
-                                        <Col span={24}>
-                                            <Checkbox value="httptohttps">HTTP Rewrite HTTPs</Checkbox>
-                                        </Col>
-                                    </Row>
-                                </Checkbox.Group>
-                            )}
-                            <FormItem>
-                                {getFieldDecorator("rule_extensions_round", { initialValue: rule_round || 'round-robin' })(
-                                    <Select placeholder="请选择负载均衡类型">
-                                        <Option value="round-robin">轮询</Option>
-                                        {/* <Option value="random">random</Option>
-                                    <Option value="consistence-hash">consistence-hash</Option> */}
-                                    </Select>
-                                )}
-                            </FormItem>
-                        </FormItem>
+
                     </Form>
                     <div
                         style={{

--- a/src/components/HttpTable/index.js
+++ b/src/components/HttpTable/index.js
@@ -29,7 +29,7 @@ export default class HttpTable extends PureComponent {
     constructor(props) {
         super(props);
         this.state = {
-            drawerVisible: false,
+            drawerVisible: this.props.open?this.props.open:false,
             information_connect: false,
             outerEnvs: [],
             dataList: [],
@@ -46,8 +46,8 @@ export default class HttpTable extends PureComponent {
             group_name: '',
             appStatusVisable: false,
             record: '',
-            parameterVisible:false,
-            parameterList:null
+            parameterVisible: false,
+            parameterList: null
         }
     }
     componentWillMount() {
@@ -99,16 +99,16 @@ export default class HttpTable extends PureComponent {
             type: "gateWay/getParameter",
             payload: {
                 team_name: globalUtil.getCurrTeamName(),
-                rule_id:values.http_rule_id,
+                rule_id: values.http_rule_id,
             },
             callback: (res) => {
-                if(res._code==200){
-                    this.setState({parameterVisible:values,parameterList:res.bean&&res.bean.value})
+                if (res._code == 200) {
+                    this.setState({ parameterVisible: values, parameterList: res.bean && res.bean.value })
                 }
             }
         })
 
-        
+
     }
     handleClick = () => {
         this.setState({ drawerVisible: true })
@@ -140,12 +140,13 @@ export default class HttpTable extends PureComponent {
                     }
                     if (data) {
                         notification.success({ message: data.msg_show || '添加成功' })
+                        this.setState({
+                            drawerVisible: false,
+                            editInfo: ''
+                        })
+                        this.reload()
                     }
-                    this.setState({
-                        drawerVisible: false,
-                        editInfo: ''
-                    })
-                    this.reload()
+
                 }
             })
         } else {
@@ -160,12 +161,12 @@ export default class HttpTable extends PureComponent {
                 callback: (data) => {
                     if (data) {
                         notification.success({ message: data.msg_show || '编辑成功' })
+                        this.setState({
+                            drawerVisible: false,
+                            editInfo: ''
+                        })
+                        this.load()
                     }
-                    this.setState({
-                        drawerVisible: false,
-                        editInfo: ''
-                    })
-                    this.load()
                 }
             })
         }
@@ -187,24 +188,24 @@ export default class HttpTable extends PureComponent {
     }
 
 
-    handleOkParameter = (values)=>{
+    handleOkParameter = (values) => {
         const { dispatch } = this.props;
-        let value={
-            proxy_body_size:Number(values.proxy_body_size),
-            proxy_connect_timeout:Number(values.proxy_connect_timeout),
-            proxy_read_timeout:Number(values.proxy_read_timeout),
-            proxy_send_timeout:Number(values.proxy_send_timeout),
-            set_headers:values.set_headers?values.set_headers:[],
+        let value = {
+            proxy_body_size: Number(values.proxy_body_size),
+            proxy_connect_timeout: Number(values.proxy_connect_timeout),
+            proxy_read_timeout: Number(values.proxy_read_timeout),
+            proxy_send_timeout: Number(values.proxy_send_timeout),
+            set_headers: values.set_headers ? values.set_headers : [],
         }
         dispatch({
             type: "gateWay/editParameter",
             payload: {
                 team_name: globalUtil.getCurrTeamName(),
-                rule_id:this.state.parameterVisible.http_rule_id,
+                rule_id: this.state.parameterVisible.http_rule_id,
                 value
             },
             callback: (data) => {
-               this.handleCloseParameter()
+                this.handleCloseParameter()
             }
         })
     }
@@ -229,10 +230,10 @@ export default class HttpTable extends PureComponent {
         this.setState({ InfoConnectModal: true })
     }
 
-    handleParameterInfo = () =>{
+    handleParameterInfo = () => {
 
     }
-    
+
     handleCancel = () => {
         this.setState({ information_connect: false })
     }
@@ -352,10 +353,10 @@ export default class HttpTable extends PureComponent {
                 if (data && data.bean.status == "closed") {
                     this.setState({ appStatusVisable: true, record })
                     winHandler.close()
-                }else if(data && data.bean.status == "undeploy"){
-                    notification.warning({message:"当前服务属于未部署状态", duration: 5});
+                } else if (data && data.bean.status == "undeploy") {
+                    notification.warning({ message: "当前服务属于未部署状态", duration: 5 });
                     that.props.dispatch(routerRedux.push(`/team/${globalUtil.getCurrTeamName()}/region/${globalUtil.getCurrRegionName()}/app/${record.service_alias}`))
-                } 
+                }
                 else {
                     winHandler.location.href = record.domain_name;
                 }
@@ -388,15 +389,15 @@ export default class HttpTable extends PureComponent {
         })
     }
 
-    handleCloseParameter = () =>{
+    handleCloseParameter = () => {
         this.setState({
             parameterVisible: false,
-            parameterList:null
+            parameterList: null
         })
     }
     render() {
-        const { dataList, loading, drawerVisible,parameterVisible, information_connect, outerEnvs, total, page_num, page_size, whether_open_form, appStatusVisable ,parameterList} = this.state;
-        const {addHttpLoading} = this.props;
+        const { dataList, loading, drawerVisible, parameterVisible, information_connect, outerEnvs, total, page_num, page_size, whether_open_form, appStatusVisable, parameterList } = this.state;
+        const { addHttpLoading } = this.props;
         const columns = [{
             title: '域名',
             dataIndex: 'domain_name',
@@ -464,7 +465,7 @@ export default class HttpTable extends PureComponent {
                 return (
                     record.is_outer_service == 1 ? <div style={{ display: "flex", justifyContent: "space-around" }}>
                         <a onClick={this.handleParameterVisibleClick.bind(this, record)}>参数配置</a>
-                        <a onClick={this.handleConectInfo.bind(this, record)}>连接信息</a>
+                        {/* <a onClick={this.handleConectInfo.bind(this, record)}>连接信息</a> */}
                         <a onClick={this.handleEdit.bind(this, record)}>编辑</a>
                         <a onClick={this.handleDelete.bind(this, record)}>删除</a>
                     </div> : <Tooltip placement="topLeft" title="请开启对外服务方可操作" arrowPointAtCenter>
@@ -478,7 +479,7 @@ export default class HttpTable extends PureComponent {
         return (
             <div className={styles.tdPadding}>
                 <Row style={{ display: "flex", alignItems: "center", width: "100%", marginBottom: "20px" }}>
-                    <Search onSearch={this.handleSearch}/>
+                    <Search onSearch={this.handleSearch} />
                     <Button type="primary" icon="plus" style={{ position: "absolute", right: "0" }} onClick={this.handleClick} loading={addHttpLoading}>
                         添加策略
                     </Button>
@@ -503,8 +504,8 @@ export default class HttpTable extends PureComponent {
                     ref={this.saveForm}
                     editInfo={this.state.editInfo}
                 />}
-                {parameterVisible&&
-                    <ParameterForm  onOk={this.handleOkParameter}   onClose={this.handleCloseParameter} visible={parameterVisible} editInfo={parameterList}/>
+                {parameterVisible &&
+                    <ParameterForm onOk={this.handleOkParameter} onClose={this.handleCloseParameter} visible={parameterVisible} editInfo={parameterList} />
                 }
                 {information_connect && <InfoConnectModal visible={information_connect} dataSource={outerEnvs} onCancel={this.handleCancel} />}
                 {whether_open_form && <Modal

--- a/src/components/Port/index.js
+++ b/src/components/Port/index.js
@@ -352,10 +352,10 @@ export default class Index extends PureComponent {
                                 <a
                                   href={(domain.protocol === 'http'
                                     ? 'http'
-                                    : 'https') + '://' + domain.domain_name}
+                                    : 'https') + '://' + domain.domain_name + (domain.domain_path ? domain.domain_path : "/")}
                                   target="_blank">{(domain.protocol === 'http'
                                     ? 'http'
-                                    : 'https') + '://' + domain.domain_name}</a>
+                                    : 'https') + '://' + domain.domain_name + (domain.domain_path ? domain.domain_path : "/")}</a>
                                 <a
                                   title="解绑"
                                   onClick={() => {
@@ -390,10 +390,10 @@ export default class Index extends PureComponent {
                             <a
                               href={(domain.protocol === 'http'
                                 ? 'http'
-                                : 'https') + '://' + domain.domain_name}
+                                : 'https') + '://' + domain.domain_name + (domain.domain_path ? domain.domain_path : "/")}
                               target="_blank">{(domain.protocol === 'http'
                                 ? 'http'
-                                : 'https') + '://' + domain.domain_name}</a>
+                                : 'https') + '://' + domain.domain_name + (domain.domain_path ? domain.domain_path : "/")}</a>
                             <a
                               title="解绑"
                               onClick={() => {
@@ -408,11 +408,11 @@ export default class Index extends PureComponent {
                     </div>
                   })
                   }
-                  <Button size="small" onClick={this.onAddDomain}>新增域名</Button>
+                  <Button size="small" onClick={this.onAddDomain}>添加域名</Button>
                 </div>
                 : null
               }
-              {outerUrl?
+              {outerUrl ?
                 <div>
                   {tcp_domains.map((domain) => {
                     return <div>
@@ -426,18 +426,30 @@ export default class Index extends PureComponent {
                       }
                     </div>
                   })}
-                </div>:
+                </div> :
                 <div>
-                {tcp_domains.map((domain) => {
-                  return <div>
-                    {
-                      <p>
+                  {tcp_domains.map((domain) => {
+                    return <div>
+                      {
+                        <p>
                           <a href="javascript:void(0)" disabled>{domain.end_point}</a>
-                      </p>
-                    }
-                  </div>
-                })}
-              </div>
+                        </p>
+                      }
+                    </div>
+                  })}
+
+                  <Link to={`/team/${globalUtil.getCurrTeamName()}/region/${globalUtil.getCurrRegionName()}/gateway/control/tcp`} style={{
+                    wordBreak: "break-all",
+                    wordWrap: "break-word",
+                    color: "#1890ff"
+                  }}>
+                    <Button size="small">
+                      管理访问策略
+                  </Button>
+                  </Link>
+
+
+                </div>
               }
             </td>
             }

--- a/src/components/TcpDrawerForm/index.js
+++ b/src/components/TcpDrawerForm/index.js
@@ -192,6 +192,8 @@ class DrawerForm extends PureComponent {
                     }}
                 >
                     <Form>
+                        <h3 style={{ borderBottom: "1px solid #BBBBBB", marginBottom: "10px" }}>路由规则</h3>
+
                         <FormItem
                             {...formItemLayout}
                             label="IP"
@@ -203,6 +205,8 @@ class DrawerForm extends PureComponent {
                                 <PortInput domain_port={editInfo && editInfo.end_point ? current_enpoint : domain_port} onChange={this.handleChange} />
                             )}
                         </FormItem>
+                        <h3 style={{ borderBottom: "1px solid #BBBBBB", marginBottom: "10px" }}>访问目标</h3>
+
                         <FormItem
                             {...formItemLayout}
                             label="应用(组)"
@@ -229,7 +233,7 @@ class DrawerForm extends PureComponent {
                         >
                             {getFieldDecorator('service_id', {
                                 rules: [{ required: true, message: '请选择' }],
-                                initialValue: editInfo && editInfo.service_id ? editInfo.service_id : this.state.serviceComponentList && this.state.serviceComponentList.length > 0 ? this.state.serviceComponentList[0].service_id : "",
+                                initialValue: editInfo && editInfo.service_id ? editInfo.service_id : this.state.serviceComponentList && this.state.serviceComponentList.length > 0 ? this.state.serviceComponentList[0].service_id : undefined,
                             })(
                                 <Select placeholder="请选择服务组件" onChange={this.handlePorts}>
                                     {
@@ -248,7 +252,7 @@ class DrawerForm extends PureComponent {
                         >
                             {getFieldDecorator('container_port', {
                                 rules: [{ required: true, message: '请选择端口号' }],
-                                initialValue: editInfo && editInfo.container_port ? editInfo.container_port : this.state.portList && this.state.portList.length > 0 ? this.state.portList[0].container_port : "",
+                                initialValue: editInfo && editInfo.container_port ? editInfo.container_port : this.state.portList && this.state.portList.length > 0 ? this.state.portList[0].container_port : undefined,
                             })(
                                 <Select placeholder="请选择端口号">
                                     {

--- a/src/routes/App/index.js
+++ b/src/routes/App/index.js
@@ -447,7 +447,7 @@ class Main extends PureComponent {
             team_name: globalUtil.getCurrTeamName(),
             app_alias: this.getAppAlias(),
             group_version: group_version ? group_version : "",
-            is_upgrate: is_upgrate?false:build_upgrade
+            is_upgrate:build_upgrade
         }).then((data) => {
             this.setState({ deployCanClick: false })
             if (data) {
@@ -779,7 +779,6 @@ class Main extends PureComponent {
         if (!appDetail.service) {
             return null;
         }
-        console.log("status",appDetail.service.service_source)
         const menu = (
             <Menu onClick={this.handleDropClick}>
                 {!appDetail.is_third && <Menu.Item

--- a/src/routes/App/members.js
+++ b/src/routes/App/members.js
@@ -301,21 +301,6 @@ export default class Index extends React.Component {
         });
     };
     handleSubmit = (vals) => {
-        const { startProbe } = this.props
-        if (appProbeUtil.isStartProbeUsed(startProbe)) {
-            this.props.dispatch({
-                type: "appControl/editStartProbe",
-                payload: {
-                    team_name: globalUtil.getCurrTeamName(),
-                    app_alias: this.props.appAlias,
-                    ...vals,
-                },
-                callback: () => {
-                    this.handleCancel();
-                    this.fetchStartProbe();
-                },
-            });
-        } else {
             this.props.dispatch({
                 type: "appControl/addStartProbe",
                 payload: {
@@ -328,7 +313,23 @@ export default class Index extends React.Component {
                     this.fetchStartProbe();
                 },
             });
-        }
+    }
+
+    handleSubmitEdit = (vals) => {
+        const { startProbe } = this.props
+            this.props.dispatch({
+                type: "appControl/editStartProbe",
+                payload: {
+                    team_name: globalUtil.getCurrTeamName(),
+                    app_alias: this.props.appAlias,
+                    ...vals,
+                    old_mode:startProbe.mode
+                },
+                callback: () => {
+                    this.handleCancel();
+                    this.fetchStartProbe();
+                },
+            });
     }
 
     handleCancel = () => {
@@ -524,7 +525,7 @@ export default class Index extends React.Component {
                 {this.state.showHealth && (
                     <EditHealthCheck
                         ports={ports}
-                        onOk={this.handleSubmit}
+                        onOk={this.handleSubmitEdit}
                         title="健康检测"
                         data={startProbe}
                         onCancel={this.handleCancel}

--- a/src/routes/App/resource.js
+++ b/src/routes/App/resource.js
@@ -759,7 +759,13 @@ class JAVA extends PureComponent {
                 {
                     (languageType == "java-war" || languageType == "Java-war") &&
                     <div>
-
+                        <Form.Item {...formItemLayout} label="开启清除构建缓存">
+                            {getFieldDecorator('NO_CACHE', {
+                                initialValue: ""
+                            })(
+                                <Radio onClick={() => { this.handleRadio("NO_CACHE") }} checked={this.state.NO_CACHE} ></Radio>
+                            )}
+                        </Form.Item>
                         <Form.Item {...formItemLayout} label="选择JDK版本">
                             {getFieldDecorator('RUNTIMES', {
                                 initialValue: (runtimeInfo && runtimeInfo.BUILD_RUNTIMES) ? "OpenJDK" : (runtimeInfo && runtimeInfo.BUILD_ENABLE_ORACLEJDK) ? "Jdk" : "OpenJDK"

--- a/src/routes/GateWay/control.js
+++ b/src/routes/GateWay/control.js
@@ -12,11 +12,12 @@ class Control extends Component {
     constructor(props) {
         super(props)
         this.state = {
-            tabKey:"http"
+            tabKey:(props.match&&props.match.params&&props.match.params.types&&props.match.params.types)?props.match.params.types:"http",
+            open:(this.props.match&&this.props.match.params&&this.props.match.params.types&&this.props.match.params.types)?this.props.match.params.types:false
         }
     }
     handleTabChange=(key)=>{
-        this.setState({ tabKey: key });
+        this.setState({ tabKey: key ,open:false});
     }
     renderContent=()=>{
         const { currUser } = this.props;
@@ -27,7 +28,7 @@ class Control extends Component {
     //   }
         const {tabKey} = this.state;
         if(tabKey=="http"){
-            return <HttpTable/>
+            return <HttpTable open={this.state.open}/>
         }else if(tabKey=="tcp"){
             return <TcpTable/>
         }

--- a/src/routes/GateWay/license.js
+++ b/src/routes/GateWay/license.js
@@ -43,12 +43,14 @@ class Control extends Component {
         page_size
       },
       callback: (data) => {
-        this.setState({
-          licenseList: data.list,
-          total: data.bean.nums,
-          editData: '',
-          licenseLoading: false
-        })
+        if(data){
+          this.setState({
+            licenseList: data.list,
+            total: data.bean.nums,
+            editData: '',
+            licenseLoading: false
+          })
+        }
       }
     })
   }

--- a/src/routes/Group/AppList.js
+++ b/src/routes/Group/AppList.js
@@ -381,7 +381,7 @@ export default class AppList extends PureComponent {
         render: (val, data) => (
           <Fragment>
             {" "}
-            {appStatusUtil.canRestart(data) && data.service_source && data.service_source != "third_party" ? (
+            {appStatusUtil.canRestart(data) && (data.service_source && data.service_source != "third_party") ? (
               <a
                 onClick={() => {
                   this.handleReStart(data);
@@ -394,7 +394,7 @@ export default class AppList extends PureComponent {
                 重启{" "}
               </a>
             ) : null}{" "}
-            {appStatusUtil.canStart(data) && data.service_source && data.service_source != "third_party" ? (
+            {appStatusUtil.canStart(data) && (data.service_source && data.service_source != "third_party") ? (
               <a
                 onClick={() => {
                   this.handleStart(data);
@@ -407,7 +407,7 @@ export default class AppList extends PureComponent {
                 启动{" "}
               </a>
             ) : null}{" "}
-            {appStatusUtil.canStop(data) ? (
+            {appStatusUtil.canStop(data)&& (data.service_source && data.service_source != "third_party")  ? (
               <a
                 onClick={() => {
                   this.handleStop(data);

--- a/src/services/app.js
+++ b/src/services/app.js
@@ -1189,6 +1189,7 @@ export async function editStartProbe(body = {
       timeout_second: body.timeout_second,
       success_threshold: body.success_threshold,
       is_used: body.is_used === void 0 ? true : body.is_used,
+      old_mode:body.old_mode?body.old_mode:""
     },
   });
 }


### PR DESCRIPTION
简化HTTP默认的添加表单
增加服务-端口管理-http和tcp添加策略的入口和提醒
移除http访问策略-操作列表中的连接信息（腾出空间）
》 具体交互体验，查看原型设计

![image](https://user-images.githubusercontent.com/32888522/55154217-30a7fe80-518f-11e9-83e3-a4f71b8981ca.png)
![image](https://user-images.githubusercontent.com/32888522/55154229-3867a300-518f-11e9-9ce3-98110c168eeb.png)
![image](https://user-images.githubusercontent.com/32888522/55154253-47e6ec00-518f-11e9-96f6-588382b67971.png)
![image](https://user-images.githubusercontent.com/32888522/55154271-50d7bd80-518f-11e9-8027-a2dddcc17367.png)
