### PR TITLE
Fix bug : New source code, image creation, will automatically popup n…

### DIFF
--- a/src/components/GlobalRouter/index.js
+++ b/src/components/GlobalRouter/index.js
@@ -254,17 +254,16 @@ export default class GlobalRouter extends PureComponent {
     const { showMenu, collapsed, pathname, menuData } = this.props;
     const { openKeys } = this.state;
     // Don't show popup menu when it is been collapsed
-    const menuProps = collapsed
-      ? {}
-      : {
-          openKeys,
-        };
+    // const menuProps = collapsed
+    //   ? {}
+    //   : {
+    //       openKeys,
+    //     };
     // if pathname can't match, use the nearest parent's key
     let selectedKeys = this.getSelectedMenuKeys(pathname);
     if (!selectedKeys.length) {
       selectedKeys = [openKeys[openKeys.length - 1]];
     }
-    // console.log(selectedKeys);
     return (
       <div
         style={{
@@ -278,7 +277,7 @@ export default class GlobalRouter extends PureComponent {
           key="Menu"
           theme="dark"
           mode="inline"
-          {...menuProps}
+          // {...menuProps}
           onOpenChange={this.handleOpenChange}
           selectedKeys={selectedKeys}
           inlineCollapsed="menu-fold"

--- a/src/components/GlobalRouter/index.js
+++ b/src/components/GlobalRouter/index.js
@@ -253,12 +253,6 @@ export default class GlobalRouter extends PureComponent {
   render() {
     const { showMenu, collapsed, pathname, menuData } = this.props;
     const { openKeys } = this.state;
-    // Don't show popup menu when it is been collapsed
-    // const menuProps = collapsed
-    //   ? {}
-    //   : {
-    //       openKeys,
-    //     };
     // if pathname can't match, use the nearest parent's key
     let selectedKeys = this.getSelectedMenuKeys(pathname);
     if (!selectedKeys.length) {
@@ -277,7 +271,6 @@ export default class GlobalRouter extends PureComponent {
           key="Menu"
           theme="dark"
           mode="inline"
-          // {...menuProps}
           onOpenChange={this.handleOpenChange}
           selectedKeys={selectedKeys}
           inlineCollapsed="menu-fold"


### PR DESCRIPTION
1、To solve the problem ： New source code, image creation, will automatically popup new left
2、solution ：Note: To use openKeys, then onOpenChange to modify the data
3、test results ：Menu does not automatically open the secondary Menu