### PR TITLE
Fix bug Details cannot be entered on the edit page

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "codemirror": "5.53.2",
     "dagre": "0.8.4",
     "deep-equal": "^2.0.1",
-    "draft-js": "0.11.5",
-    "draft-js-prism": "^1.0.6",
     "draftjs-utils": "0.10.2",
     "dva": "^2.4.1",
     "enquire-js": "^0.1.1",


### PR DESCRIPTION
1、To solve the problem ：Details cannot be entered on the edit page
2、solution ：After Braft-Editor, draft-JS or its associated packages can no longer be loaded
3、test results : Details can be found on the edit page