### PR TITLE
Fix bug The log window cannot be opened while in build state

### DIFF
--- a/src/pages/Component/component/LogShow/index.js
+++ b/src/pages/Component/component/LogShow/index.js
@@ -197,9 +197,6 @@ class Index extends React.Component {
     }
     const isDownloadb = bodyText.length >= 1024*1024 && !dynamic;
 
-    if (bodyText.length === 0) {
-      return <div />;
-    }
     return (
       <Modal
         className={!isDownloadb && styles.logModal}


### PR DESCRIPTION
1、To solve the problem ： The log window cannot be opened while in build state
2、solution ：bodyText
3、test results : The log window can be opened in the build state