### PR TITLE
Fix bug  New users cause page refresh cycles before Rainbond is bound

### DIFF
--- a/src/layouts/UserLayout.js
+++ b/src/layouts/UserLayout.js
@@ -18,6 +18,7 @@ class UserLayout extends React.PureComponent {
   }
   componentWillMount() {
     const { dispatch } = this.props;
+    const disableAutoLogin = rainbondUtil.OauthParameter('disable_auto_login');
     // 初始化 获取RainbondInfo信息
     dispatch({
       type: 'global/fetchRainbondInfo',
@@ -39,11 +40,14 @@ class UserLayout extends React.PureComponent {
             });
           }
           if (isOauth && oauthInfo) {
-            if (oauthInfo.is_auto_login) {
+            if (oauthInfo.is_auto_login && disableAutoLogin != 'true') {
               globalUtil.removeCookie();
               window.location.href = oauthUtil.getAuthredictURL(oauthInfo);
+            } else if (disableAutoLogin) {
+              this.isRender(true);
+            } else {
+              this.isRender(!oauthInfo.is_auto_login);
             }
-            this.isRender(!oauthInfo.is_auto_login);
           } else {
             this.isRender(true);
           }

--- a/src/pages/User/ThirdLogin.js
+++ b/src/pages/User/ThirdLogin.js
@@ -83,6 +83,8 @@ export default class LoginPage extends Component {
     let oauthServer = null;
     // eslint-disable-next-line no-unused-expressions
     rainbondUtil.OauthbEnable(rainbondInfo) &&
+      rainbondInfo.oauth_services &&
+      rainbondInfo.oauth_services.value &&
       rainbondInfo.oauth_services.value.map((item) => {
         if (item.service_id == service_id) {
           oauthServer = item;

--- a/src/pages/User/ThirdRegister.js
+++ b/src/pages/User/ThirdRegister.js
@@ -99,6 +99,8 @@ export default class Register extends Component {
     let oauthServer = null;
     // eslint-disable-next-line no-unused-expressions
     rainbondUtil.OauthbEnable(rainbondInfo) &&
+      rainbondInfo.oauth_services &&
+      rainbondInfo.oauth_services.value &&
       rainbondInfo.oauth_services.value.map((item) => {
         if (item.service_id == service_id) {
           oauthServer = item;


### PR DESCRIPTION
1、To solve the problem ：New users cause page refresh cycles before Rainbond is bound
2、solution ：disable_auto_login
3、test results : New users jump to the login page without binding Rainbond