### PR TITLE
Fix bug the Edit user setting a new password should not be mandatory

### DIFF
--- a/src/components/CreatUserForm/index.js
+++ b/src/components/CreatUserForm/index.js
@@ -53,7 +53,10 @@ class CreateUserForm extends PureComponent {
   };
 
   checkAccountPass = (_, value, callback) => {
-    if (!value) {
+    const { userInfo } = this.props;
+    if (userInfo && !value) {
+      callback();
+    } else if (!value) {
       callback('请填写密码');
     } else if (value && value.length < 8) {
       callback('密码长度至少为8位');
@@ -140,7 +143,12 @@ class CreateUserForm extends PureComponent {
                     validator: this.checkAccountPass
                   }
                 ]
-              })(<Input.Password placeholder="请填写密码" />)}
+              })(
+                <Input.Password
+                  autoComplete="new-password"
+                  placeholder="请填写密码"
+                />
+              )}
             </FormItem>
           )}
 
@@ -153,7 +161,12 @@ class CreateUserForm extends PureComponent {
                     validator: this.checkAccountPass
                   }
                 ]
-              })(<Input.Password placeholder="留空则不修改密码" />)}
+              })(
+                <Input.Password
+                  autoComplete="new-password"
+                  placeholder="留空则不修改密码"
+                />
+              )}
             </FormItem>
           )}
 


### PR DESCRIPTION
1、To solve the problem ：Edit user setting a new password should not be mandatory
2、solution ：userInfo && !value
3、test results : Edit user to set a new password is not required