### PR TITLE
Fix   the  Publish page API requests loop around too often, so it wil…

### DIFF
--- a/src/pages/Group/AppShareLoading.js
+++ b/src/pages/Group/AppShareLoading.js
@@ -90,7 +90,7 @@ class ShareEvent extends React.Component {
               status: res.bean.event_status
             },
             () => {
-              this.handleStatus();
+              this.handleSendStatus();
               setTimeout(() => {
                 this.getShareStatus();
               }, 5000);
@@ -101,11 +101,16 @@ class ShareEvent extends React.Component {
     });
   };
   handleStatus = () => {
-    const { onSuccess, onFail } = this.props;
     const { status } = this.state;
     if (status === 'start') {
       this.getShareStatus();
+    } else {
+      this.handleSendStatus();
     }
+  };
+  handleSendStatus = () => {
+    const { status } = this.state;
+    const { onSuccess, onFail } = this.props;
     if (status === 'success' && onSuccess) {
       onSuccess();
     }


### PR DESCRIPTION
1、To solve the problem ： Publish page API requests loop around too often, so it will report an error under SQLite database
2、solution ：Calling handleStatus in a loop causes the API interface to be sent constantly
3、test results :Publisher page API requests are called every 5 seconds