### PR TITLE
Fix   the  User management page set user role error report

### DIFF
--- a/src/components/CurrentTeams/index.js
+++ b/src/components/CurrentTeams/index.js
@@ -51,8 +51,12 @@ class currentTeams extends PureComponent {
     this.setState({ editRoleLoading: true });
     const { dispatch, eid, userInfo } = this.props;
     const { toEditAction } = this.state;
+    let type = 'user/editUserRoles';
+    if (toEditAction.roles && toEditAction.roles.length > 0) {
+      type = 'teamControl/editMember';
+    }
     dispatch({
-      type: 'user/editUserRoles',
+      type,
       payload: {
         enterprise_id: eid,
         team_name: toEditAction.team_name,


### PR DESCRIPTION
1、To solve the problem ：User management page set user role error report
2、solution ：Modified the API interface
3、test results :The user management page successfully set the user role