### PR TITLE
Fix bug  the  An error pops up when installing the RainBond cluster

### DIFF
--- a/src/components/Cluster/RainbondClusterInit/index.js
+++ b/src/components/Cluster/RainbondClusterInit/index.js
@@ -91,8 +91,9 @@ export default class RainbondClusterInit extends PureComponent {
           cloud.handleCloudAPIError(res);
         }
       });
+    } else {
+      notification.warning({ message: '请阅读并同意注意事项' });
     }
-    notification.warning('请阅读并同意注意事项');
   };
 
   loadTask = noopen => {
@@ -295,7 +296,6 @@ export default class RainbondClusterInit extends PureComponent {
               上一步
             </Button>
             <Button
-              disabled={!checked}
               loading={loading}
               onClick={this.initRainbondCluster}
               type="primary"


### PR DESCRIPTION
1、To solve the problem ：An error pops up when installing the RainBond cluster
2、solution ：notification.warning
3、test results :When installing the RainBond cluster, the pop-up does not report an error