### PR TITLE
Fix the Wait for the cluster installation screen, refresh and jump di…

### DIFF
--- a/src/layouts/EnterpriseLayout.js
+++ b/src/layouts/EnterpriseLayout.js
@@ -140,7 +140,14 @@ class EnterpriseLayout extends PureComponent {
       },
       callback: res => {
         const adminer = userUtil.isCompanyAdmin(currentUser);
-        if (res && res.list && res.list.length == 0 && adminer) {
+        const currentAddress = window.location.href;
+        if (
+          res &&
+          res.list &&
+          res.list.length === 0 &&
+          adminer &&
+          currentAddress.indexOf(`/enterprise/${eid}/provider/`) === -1
+        ) {
           dispatch(routerRedux.push(`/enterprise/${eid}/addCluster?init=true`));
         }
       }


### PR DESCRIPTION
1、To solve the problem ：Wait for the cluster installation screen to appear, refresh and jump directly to the installation cluster page before starting the installation
2、solution ：Determine whether the current page in the installation cluster page is not jump
3、test results :Wait for the cluster installation screen to appear and refresh without jumping before starting the installation