### PR TITLE
Fix the HELM address name validation

### DIFF
--- a/src/components/CreateHelmAppModels/index.js
+++ b/src/components/CreateHelmAppModels/index.js
@@ -42,7 +42,8 @@ class CreateHelmAppModels extends PureComponent {
     });
   };
   fetchCreateAppTeams = name => {
-    const { dispatch, eid } = this.props;
+    const { dispatch, eid, form, appTypes } = this.props;
+    const { setFieldsValue } = form;
     dispatch({
       type: 'global/fetchCreateAppTeams',
       payload: {
@@ -57,7 +58,22 @@ class CreateHelmAppModels extends PureComponent {
             },
             () => {
               if (res.list && res.list.length > 0) {
-                this.handleTeamChange(res.list[0].team_name);
+                const info = res.list[0];
+                setFieldsValue({
+                  team_name: info.team_name
+                });
+                if (
+                  appTypes === 'helmContent' &&
+                  info.region_list &&
+                  info.region_list.length > 0
+                ) {
+                  this.handleCheckAppName(
+                    true,
+                    info.team_name,
+                    info.region_list[0].region_name
+                  );
+                }
+                this.handleTeamChange(info.team_name);
               }
             }
           );
@@ -82,13 +98,13 @@ class CreateHelmAppModels extends PureComponent {
       callback: res => {
         let validatorValue = '';
         if (res && res.status_code === 200) {
+          const appname = (res.list && res.list.name) || '';
           if (initial) {
             this.setState({
-              appName: (res.list && res.list.name) || ''
+              appName: appname
             });
           } else if (callbacks) {
-            validatorValue =
-              name === (res.list && res.list.name) ? '' : '应用名称已存在';
+            validatorValue = name === appname ? '' : '应用名称已存在';
             if (validatorValue) {
               callbacks(validatorValue);
             } else {
@@ -221,15 +237,13 @@ class CreateHelmAppModels extends PureComponent {
         setFieldsValue({
           region_name: regionName
         });
-        if (appTypes === 'helmContent') {
-          if (getFieldValue('app_name') !== '') {
-            this.handleCheckAppName(
-              false,
-              teamName,
-              regionName,
-              getFieldValue('app_name')
-            );
-          }
+        if (appTypes === 'helmContent' && getFieldValue('app_name') !== '') {
+          this.handleCheckAppName(
+            false,
+            teamName,
+            regionName,
+            getFieldValue('app_name')
+          );
         } else {
           this.fetchGroup(teamName, regionName);
         }

--- a/src/components/HelmForm/index.js
+++ b/src/components/HelmForm/index.js
@@ -118,9 +118,9 @@ export default class Index extends PureComponent {
     if (name.length > 32) {
       return callbacks('最大长度32位');
     }
-    const pattern = /^[a-z][a-zA-Z0-9]+$/;
+    const pattern = /^[a-z][a-z0-9]+$/;
     if (!name.match(pattern)) {
-      return callbacks('只支持小写字母开头、字母和数字组合');
+      return callbacks('只支持小写字母开头、小写字母和数字组合');
     }
 
     dispatch({
@@ -148,7 +148,6 @@ export default class Index extends PureComponent {
     });
   };
   handleError = res => {
-    console.log(res);
     if (res && res.data && res.data.code) {
       notification.warning({
         message: '仓库名称已存在'
@@ -199,6 +198,10 @@ export default class Index extends PureComponent {
               {
                 required: true,
                 message: '请填写商店地址'
+              },
+              {
+                pattern: /^[^\s]*$/,
+                message: '禁止输入空格'
               }
             ]
           })(<Input type="text" placeholder="请填写商店地址" />)}


### PR DESCRIPTION
1、To solve the problem ：HELM address name validation
2、solution ：As soon as the page comes in, it starts loading the interface and verifies whether there are any duplicate Helm app names. If there are duplicate Helm app names, a new Helm name will be automatically generated and assigned
3、test results : HELM addresses cannot be entered in blank names. Only lowercase letters are supported