### PR TITLE
Fix the Obtain officially supported entry and can view log after failure

### DIFF
--- a/src/components/Cluster/ClusterCreationLog/index.js
+++ b/src/components/Cluster/ClusterCreationLog/index.js
@@ -1,0 +1,83 @@
+import Ansi from '@/components/Ansi';
+import cloud from '@/utils/cloud';
+import { Modal, Spin } from 'antd';
+import { connect } from 'dva';
+import React, { PureComponent } from 'react';
+import styles from '../../CreateTeam/index.less';
+import istyles from './index.less';
+
+@connect()
+export default class ClusterCreationLog extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      createLog: '',
+      showCreateLog: true
+    };
+  }
+  componentDidMount() {
+    this.queryCreateLog();
+  }
+
+  getLineHtml = (lineNumber, line) => {
+    return (
+      <div className={istyles.logline} key={lineNumber}>
+        <a>{lineNumber}</a>
+        <Ansi>{line}</Ansi>
+      </div>
+    );
+  };
+
+  queryCreateLog = () => {
+    const { dispatch, eid, selectProvider, clusterID } = this.props;
+    dispatch({
+      type: 'cloud/queryCreateLog',
+      payload: {
+        enterprise_id: eid,
+        provider_name: selectProvider,
+        clusterID
+      },
+      callback: data => {
+        if (data) {
+          const content = data.content.split('\n');
+          this.setState({ createLog: content, showCreateLog: false });
+        }
+      },
+      handleError: res => {
+        cloud.handleCloudAPIError(res);
+      }
+    });
+  };
+
+  render() {
+    const { title, onCancel } = this.props;
+    const { createLog, showCreateLog } = this.state;
+    return (
+      <Modal
+        title={title || '集群创建日志'}
+        visible
+        className={styles.TelescopicModal}
+        onCancel={onCancel}
+        onOk={this.onOk}
+        width={1000}
+        maskClosable={false}
+        bodyStyle={{ background: '#000' }}
+        footer={null}
+      >
+        <div className={istyles.cmd}>
+          {showCreateLog ? (
+            <div style={{ textAlign: 'center' }}>
+              <Spin spinning className={istyles.customSpin} />
+            </div>
+          ) : (
+            createLog &&
+            createLog.length > 0 &&
+            createLog.map((line, index) => {
+              return this.getLineHtml(index + 1, line);
+            })
+          )}
+        </div>
+      </Modal>
+    );
+  }
+}

--- a/src/components/Cluster/ClusterCreationLog/index.less
+++ b/src/components/Cluster/ClusterCreationLog/index.less
@@ -1,0 +1,36 @@
+@import '~antd/lib/style/themes/default.less';
+@import '../../../utils/utils.less';
+
+.cmd {
+  background: #000;
+  color: #fff;
+  line-height: 16px;
+  display: block;
+  font-size: 10px;
+  font-family: PingFangSC-Regular, sans-serif;
+}
+
+.logline {
+  a {
+    display: inline-block;
+    text-align: right;
+    min-width: 40px;
+    cursor: pointer;
+    text-decoration: none;
+    padding-right: 1em;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    color: #666;
+    word-wrap: normal;
+  }
+}
+
+.customSpin {
+  :global {
+    .ant-spin-dot-item {
+      background-color: #fff;
+    }
+  }
+}

--- a/src/components/Cluster/ClusterProgressQuery/index.js
+++ b/src/components/Cluster/ClusterProgressQuery/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable react/no-array-index-key */
+import rainbondUtil from '@/utils/rainbond';
 import { Alert, Button, Modal, Popover, Row, Timeline } from 'antd';
 import { connect } from 'dva';
 import React, { PureComponent } from 'react';
@@ -31,13 +32,16 @@ class ClusterProgressQuery extends PureComponent {
       loading,
       complete,
       clusterID,
-      msg
+      msg,
+      rainbondInfo
     } = this.props;
     const { showCreateLog } = this.state;
     let pending = '进行中';
     if (complete) {
       pending = false;
     }
+    const enterpriseEdition = rainbondUtil.isEnterpriseEdition(rainbondInfo);
+
     return (
       <Modal
         title={title}
@@ -68,25 +72,29 @@ class ClusterProgressQuery extends PureComponent {
             message={
               <span>
                 {msg}
-                <Popover
-                  placement="bottom"
-                  content={
-                    <img
-                      alt="扫码加入社区钉钉群"
-                      style={{ width: '200px' }}
-                      title="扫码加入社区钉钉群"
-                      src="https://www.rainbond.com/images/dingding-group.jpeg"
-                    />
-                  }
-                  title={
-                    <div style={{ textAlign: 'center' }}>钉钉群号31096419</div>
-                  }
-                >
-                  <Button type="link" style={{ padding: 0 }}>
-                    钉钉群
-                  </Button>
-                </Popover>
-                获取官方支持
+                {!enterpriseEdition && (
+                  <Popover
+                    placement="bottom"
+                    content={
+                      <img
+                        alt="扫码加入社区钉钉群"
+                        style={{ width: '200px' }}
+                        title="扫码加入社区钉钉群"
+                        src="https://www.rainbond.com/images/dingding-group.jpeg"
+                      />
+                    }
+                    title={
+                      <div style={{ textAlign: 'center' }}>
+                        钉钉群号31096419
+                      </div>
+                    }
+                  >
+                    <Button type="link" style={{ padding: 0 }}>
+                      钉钉群
+                    </Button>
+                    获取官方支持
+                  </Popover>
+                )}
               </span>
             }
             type="info"

--- a/src/components/Cluster/ClusterProgressQuery/index.js
+++ b/src/components/Cluster/ClusterProgressQuery/index.js
@@ -1,0 +1,125 @@
+/* eslint-disable react/no-array-index-key */
+import { Alert, Button, Modal, Popover, Row, Timeline } from 'antd';
+import { connect } from 'dva';
+import React, { PureComponent } from 'react';
+import modelstyles from '../../CreateTeam/index.less';
+import ClusterCreationLog from '../ClusterCreationLog';
+import styles from '../ShowKubernetesCreateDetail/index.less';
+
+@connect(({ global }) => ({
+  rainbondInfo: global.rainbondInfo,
+  enterprise: global.enterprise
+}))
+class ClusterProgressQuery extends PureComponent {
+  constructor(arg) {
+    super(arg);
+    this.state = {
+      showCreateLog: false
+    };
+  }
+  queryCreateLog = () => {
+    this.setState({ showCreateLog: true });
+  };
+  render() {
+    const {
+      onCancel,
+      title,
+      eid,
+      selectProvider,
+      providerName,
+      steps,
+      loading,
+      complete,
+      clusterID,
+      msg
+    } = this.props;
+    const { showCreateLog } = this.state;
+    let pending = '进行中';
+    if (complete) {
+      pending = false;
+    }
+    return (
+      <Modal
+        title={title}
+        visible
+        maskClosable={false}
+        width={600}
+        onCancel={onCancel}
+        className={modelstyles.TelescopicModal}
+        footer={[
+          <Button type="primary" onClick={onCancel}>
+            关闭
+          </Button>
+        ]}
+      >
+        {showCreateLog && (
+          <ClusterCreationLog
+            eid={eid}
+            clusterID={clusterID}
+            selectProvider={selectProvider || providerName}
+            onCancel={() => {
+              this.setState({ showCreateLog: false });
+            }}
+          />
+        )}
+        <Row loading={loading} className={styles.box}>
+          <Alert
+            style={{ marginBottom: '16px' }}
+            message={
+              <span>
+                {msg}
+                <Popover
+                  placement="bottom"
+                  content={
+                    <img
+                      alt="扫码加入社区钉钉群"
+                      style={{ width: '200px' }}
+                      title="扫码加入社区钉钉群"
+                      src="https://www.rainbond.com/images/dingding-group.jpeg"
+                    />
+                  }
+                  title={
+                    <div style={{ textAlign: 'center' }}>钉钉群号31096419</div>
+                  }
+                >
+                  <Button type="link" style={{ padding: 0 }}>
+                    钉钉群
+                  </Button>
+                </Popover>
+                获取官方支持
+              </span>
+            }
+            type="info"
+            showIcon
+          />
+          <Timeline loading={loading} pending={pending}>
+            {steps.map((item, index) => {
+              const { Status, Title, Description, Message } = item;
+              return (
+                <Timeline.Item color={item.Color} key={`step${index}`}>
+                  <h4>{Title}</h4>
+                  <p>{Description}</p>
+                  <p>{Message}</p>
+                  {Status === 'failure' && (
+                    <div>
+                      <Button
+                        type="link"
+                        style={{ padding: 0 }}
+                        onClick={this.queryCreateLog}
+                      >
+                        查看日志
+                      </Button>
+                    </div>
+                  )}
+                </Timeline.Item>
+              );
+            })}
+          </Timeline>
+          {complete && <span>已结束</span>}
+        </Row>
+      </Modal>
+    );
+  }
+}
+
+export default ClusterProgressQuery;

--- a/src/components/Cluster/RKEClusterAdd/index.js
+++ b/src/components/Cluster/RKEClusterAdd/index.js
@@ -9,6 +9,7 @@ import {
   Button,
   Col,
   Form,
+  Icon,
   Input,
   InputNumber,
   message,
@@ -23,6 +24,7 @@ import {
   Tooltip,
   Typography
 } from 'antd';
+import copy from 'copy-to-clipboard';
 import { connect } from 'dva';
 import React, { PureComponent } from 'react';
 import { rkeconfig } from '../../../services/cloud';
@@ -669,33 +671,59 @@ export default class RKEClusterConfig extends PureComponent {
         width={900}
         destroyOnClose
         footer={
-          <Popconfirm
+          <Button
+            type="primary"
+            onClick={() => {
+              this.handleStartCheck();
+            }}
+            loading={loading}
+          >
+            {clusterID ? '更新集群' : '开始安装'}
+          </Button>
+        }
+        confirmLoading={loading}
+        onCancel={onCancel}
+        maskClosable={false}
+      >
+        {isCheck && (
+          <Modal
             title={`确定已完成所有节点的初始化并开始
             ${clusterID ? '配置' : '安装'}
-            集群吗?`}
-            visible={isCheck}
-            onConfirm={() => {
+           集群吗?`}
+            confirmLoading={loading}
+            className={styles.TelescopicModal}
+            width={900}
+            visible
+            onOk={() => {
               this.handleTabs(activeKey === '1' ? '2' : '1', true);
             }}
             onCancel={() => {
               this.handleCheck(false);
             }}
           >
-            <Button
-              type="primary"
-              onClick={() => {
-                this.handleStartCheck();
-              }}
-              loading={loading}
-            >
-              {clusterID ? '更新集群' : '开始安装'}
-            </Button>
-          </Popconfirm>
-        }
-        confirmLoading={loading}
-        onCancel={onCancel}
-        maskClosable={false}
-      >
+            <Row style={{ padding: '0 16px' }}>
+              <span style={{ fontWeight: 600, color: 'red' }}>
+                请在开始{clusterID ? '配置前在新加' : '安装前所有'}
+                节点先执行以下初始化命令（执行用户需要具有sudo权限）：
+              </span>
+
+              <Col span={24} style={{ marginTop: '16px' }}>
+                <span className={styles.cmd}>
+                  <Icon
+                    className={styles.copy}
+                    type="copy"
+                    onClick={() => {
+                      copy(initNodeCmd);
+                      notification.success({ message: '复制成功' });
+                    }}
+                  />
+                  {initNodeCmd}
+                </span>
+              </Col>
+            </Row>
+          </Modal>
+        )}
+
         {clusterID && (
           <Alert
             type="warning"
@@ -813,15 +841,6 @@ export default class RKEClusterConfig extends PureComponent {
               />
             )}
           </div>
-          <Row style={{ padding: '0 16px' }}>
-            <span style={{ fontWeight: 600, color: 'red' }}>
-              请在开始{clusterID ? '配置前在新加' : '安装前所有'}
-              节点先执行以下初始化命令（执行用户需要具有sudo权限）：
-            </span>
-            <Col span={24} style={{ marginTop: '16px' }}>
-              <span className={styles.cmd}>{initNodeCmd}</span>
-            </Col>
-          </Row>
         </Form>
       </Modal>
     );

--- a/src/components/Cluster/RKEClusterAdd/index.less
+++ b/src/components/Cluster/RKEClusterAdd/index.less
@@ -1,37 +1,43 @@
-@import "~antd/lib/style/themes/default.less";
-@import "../../../utils/utils.less";
-
+@import '~antd/lib/style/themes/default.less';
+@import '../../../utils/utils.less';
 
 .describe {
-    background: rgba(22, 184, 248, .1);
-    padding: 8px;
+  background: rgba(22, 184, 248, 0.1);
+  padding: 8px;
 
-    li {
-        line-height: 24px;
-    }
+  li {
+    line-height: 24px;
+  }
 }
 
 .editable-cell {
-    position: relative;
+  position: relative;
 }
 
 .editable-cell-value-wrap {
-    padding: 5px 12px;
-    cursor: pointer;
+  padding: 5px 12px;
+  cursor: pointer;
 }
 
 .editable-row:hover .editable-cell-value-wrap {
-    border: 1px solid #d9d9d9;
-    border-radius: 4px;
-    padding: 4px 11px;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  padding: 4px 11px;
 }
 
 .cmd {
-    padding: 16px;
-    background: #000;
-    color: #fff;
-    line-height: 16px;
-    display: block;
-    font-size: 10px;
-    font-family: PingFangSC-Regular, sans-serif;
+  position: relative;
+  padding: 16px;
+  background: #000;
+  color: #fff;
+  line-height: 16px;
+  display: block;
+  font-size: 10px;
+  font-family: PingFangSC-Regular, sans-serif;
+}
+.copy {
+  position: absolute;
+  right: 4px;
+  top: 5px;
+  font-size: 16px;
 }

--- a/src/components/Cluster/ShowInitRainbondDetail/index.js
+++ b/src/components/Cluster/ShowInitRainbondDetail/index.js
@@ -1,11 +1,9 @@
 /* eslint-disable react/no-array-index-key */
-import { Alert, Button, Modal, Row, Timeline } from 'antd';
 import { connect } from 'dva';
 import React, { PureComponent } from 'react';
 import cloud from '../../../utils/cloud';
 import globalUtil from '../../../utils/global';
-import modelstyles from '../../CreateTeam/index.less';
-import styles from '../ShowKubernetesCreateDetail/index.less';
+import ClusterProgressQuery from '../ClusterProgressQuery';
 
 @connect(({ global }) => ({
   rainbondInfo: global.rainbondInfo,
@@ -17,7 +15,9 @@ class InitRainbondDetail extends PureComponent {
     this.state = {
       loading: true,
       complete: false,
-      steps: []
+      steps: [],
+      clusterID: '',
+      showCreateLog: false
     };
   }
   componentDidMount() {
@@ -80,6 +80,7 @@ class InitRainbondDetail extends PureComponent {
             });
           }
           this.setState({
+            clusterID: data.clusterID,
             complete,
             loading: false,
             steps
@@ -95,49 +96,19 @@ class InitRainbondDetail extends PureComponent {
       }
     });
   };
-
+  queryCreateLog = () => {
+    this.setState({ showCreateLog: true });
+  };
   render() {
-    const { onCancel, title } = this.props;
-    const { steps, loading, complete } = this.state;
-    let pending = '进行中';
-    if (complete) {
-      pending = false;
-    }
+    const { title } = this.props;
+
     return (
-      <Modal
+      <ClusterProgressQuery
         title={title || '平台集群初始化进度查询'}
-        visible
-        maskClosable={false}
-        width={600}
-        onCancel={onCancel}
-        className={modelstyles.TelescopicModal}
-        footer={[
-          <Button type="primary" onClick={onCancel}>
-            关闭
-          </Button>
-        ]}
-      >
-        <Row loading={loading} className={styles.box}>
-          <Alert
-            style={{ marginBottom: '16px' }}
-            message="初始化流程预计耗时20分钟，请耐心等待，若遇到错误请反馈到社区"
-            type="info"
-            showIcon
-          />
-          <Timeline loading={loading} pending={pending}>
-            {steps.map((item, index) => {
-              return (
-                <Timeline.Item color={item.Color} key={`step${index}`}>
-                  <h4>{item.Title}</h4>
-                  <p>{item.Description}</p>
-                  <p>{item.Message}</p>
-                </Timeline.Item>
-              );
-            })}
-          </Timeline>
-          {complete && <span>已结束</span>}
-        </Row>
-      </Modal>
+        msg="初始化流程预计耗时20分钟，请耐心等待，若遇到错误请反馈到社区"
+        {...this.state}
+        {...this.props}
+      />
     );
   }
 }

--- a/src/components/Cluster/ShowKubernetesCreateDetail/index.js
+++ b/src/components/Cluster/ShowKubernetesCreateDetail/index.js
@@ -1,11 +1,9 @@
 /* eslint-disable react/no-array-index-key */
-import { Alert, Button, Modal, Row, Timeline } from 'antd';
 import { connect } from 'dva';
 import React, { PureComponent } from 'react';
 import cloud from '../../../utils/cloud';
 import globalUtil from '../../../utils/global';
-import modelstyles from '../../CreateTeam/index.less';
-import styles from './index.less';
+import ClusterProgressQuery from '../ClusterProgressQuery';
 
 @connect(({ global }) => ({
   rainbondInfo: global.rainbondInfo,
@@ -17,7 +15,8 @@ class ShowKubernetesCreateDetail extends PureComponent {
     this.state = {
       loading: true,
       complete: false,
-      steps: []
+      steps: [],
+      showCreateLog: false
     };
   }
   componentDidMount() {
@@ -97,49 +96,18 @@ class ShowKubernetesCreateDetail extends PureComponent {
       }
     });
   };
-
+  queryCreateLog = () => {
+    this.setState({ showCreateLog: true });
+  };
   render() {
-    const { onCancel, title } = this.props;
-    const { steps, loading, complete } = this.state;
-    let pending = '进行中';
-    if (complete) {
-      pending = false;
-    }
+    const { title } = this.props;
     return (
-      <Modal
+      <ClusterProgressQuery
         title={title || '集群创建进度'}
-        visible
-        width={600}
-        onCancel={onCancel}
-        maskClosable={false}
-        className={modelstyles.TelescopicModal}
-        footer={[
-          <Button type="primary" onClick={onCancel}>
-            关闭
-          </Button>
-        ]}
-      >
-        <Alert
-          style={{ marginBottom: '16px' }}
-          message="集群安装过程预计10分钟，请耐心等待，若遇到错误请反馈到社区"
-          type="info"
-          showIcon
-        />
-        <Row loading={loading} className={styles.box}>
-          <Timeline loading={loading} pending={pending}>
-            {steps.map((item, index) => {
-              return (
-                <Timeline.Item color={item.Color} key={`step${index}`}>
-                  <h4>{item.Title}</h4>
-                  <p>{item.Description}</p>
-                  <p>{item.Message}</p>
-                </Timeline.Item>
-              );
-            })}
-          </Timeline>
-          {complete && <span>已结束</span>}
-        </Row>
-      </Modal>
+        msg="集群安装过程预计10分钟，请耐心等待，若遇到错误请反馈到社区"
+        {...this.state}
+        {...this.props}
+      />
     );
   }
 }

--- a/src/components/Cluster/ShowUpdateClusterDetail/index.js
+++ b/src/components/Cluster/ShowUpdateClusterDetail/index.js
@@ -1,10 +1,8 @@
 /* eslint-disable react/no-array-index-key */
-import { Alert, Button, Modal, Row, Timeline } from 'antd';
 import { connect } from 'dva';
 import React, { PureComponent } from 'react';
 import cloud from '../../../utils/cloud';
-import modelstyles from '../../CreateTeam/index.less';
-import styles from '../ShowKubernetesCreateDetail/index.less';
+import ClusterProgressQuery from '../ClusterProgressQuery';
 
 @connect()
 class UpdateClusterDetail extends PureComponent {
@@ -52,47 +50,15 @@ class UpdateClusterDetail extends PureComponent {
   };
 
   render() {
-    const { onCancel, title } = this.props;
-    const { steps, loading, complete } = this.state;
-    let pending = '进行中';
-    if (complete) {
-      pending = false;
-    }
+    const { title } = this.props;
+
     return (
-      <Modal
+      <ClusterProgressQuery
         title={title || 'Kubernetes 集群配置进度查询'}
-        visible
-        maskClosable={false}
-        width={600}
-        onCancel={onCancel}
-        className={modelstyles.TelescopicModal}
-        footer={[
-          <Button type="primary" onClick={onCancel}>
-            关闭
-          </Button>
-        ]}
-      >
-        <Row loading={loading} className={styles.box}>
-          <Alert
-            style={{ marginBottom: '16px' }}
-            message="配置流程预计耗时10分钟，请耐心等待，若遇到错误请反馈到社区"
-            type="info"
-            showIcon
-          />
-          <Timeline loading={loading} pending={pending}>
-            {steps.map((item, index) => {
-              return (
-                <Timeline.Item color={item.Color} key={`step${index}`}>
-                  <h4>{item.Title}</h4>
-                  <p>{item.Description}</p>
-                  <p>{item.Message}</p>
-                </Timeline.Item>
-              );
-            })}
-          </Timeline>
-          {complete && <span>已结束</span>}
-        </Row>
-      </Modal>
+        msg="配置流程预计耗时10分钟，请耐心等待，若遇到错误请反馈到社区"
+        {...this.state}
+        {...this.props}
+      />
     );
   }
 }

--- a/src/pages/AddCluster/KClusterList/index.js
+++ b/src/pages/AddCluster/KClusterList/index.js
@@ -41,7 +41,7 @@ export default class EnterpriseClusters extends PureComponent {
       showTaskDetail: false,
       linkedClusters: new Map(),
       lastTask: {},
-      clusterID: ''
+      currentClusterID: ''
     };
   }
   componentWillMount() {
@@ -91,7 +91,7 @@ export default class EnterpriseClusters extends PureComponent {
       },
       callback: data => {
         if (data) {
-          this.setState({ lastTask: data, clusterID: data.clusterID });
+          this.setState({ lastTask: data, currentClusterID: data.clusterID });
           // to load create event
           if (data.status === 'start') {
             this.setState({ showTaskDetail: true });
@@ -139,9 +139,6 @@ export default class EnterpriseClusters extends PureComponent {
     });
   };
   handleStartLog = taskID => {
-    if (!taskID) {
-      return false;
-    }
     const {
       match: {
         params: { eid, provider }
@@ -231,6 +228,14 @@ export default class EnterpriseClusters extends PureComponent {
     return steps;
   };
 
+  handleOk = (task, upDateInfo) => {
+    this.setState(upDateInfo);
+    if (task && task.taskID) {
+      this.handleStartLog(task.taskID);
+    }
+    this.cancelAddCluster();
+    this.loadKubernetesCluster();
+  };
   renderCreateClusterShow = () => {
     const {
       match: {
@@ -247,14 +252,12 @@ export default class EnterpriseClusters extends PureComponent {
               this.cancelAddCluster();
             }}
             onOK={task => {
-              this.setState({
+              const upDateInfo = {
                 lastTask: task,
                 showTaskDetail: true,
-                clusterID: task.clusterID
-              });
-              this.handleStartLog(task && task.taskID);
-              this.cancelAddCluster();
-              this.loadKubernetesCluster();
+                currentClusterID: task.clusterID
+              };
+              this.handleOk(task, upDateInfo);
             }}
           />
         );
@@ -268,12 +271,10 @@ export default class EnterpriseClusters extends PureComponent {
               this.cancelAddCluster();
             }}
             onOK={task => {
-              this.setState({
-                clusterID: task.clusterID
-              });
-              this.handleStartLog(task && task.taskID);
-              this.loadKubernetesCluster();
-              this.cancelAddCluster();
+              const upDateInfo = {
+                currentClusterID: task.clusterID
+              };
+              this.handleOk(task, upDateInfo);
             }}
           />
         );
@@ -285,14 +286,12 @@ export default class EnterpriseClusters extends PureComponent {
               this.cancelAddCluster();
             }}
             onOK={task => {
-              this.setState({
+              const upDateInfo = {
                 lastTask: task,
                 showTaskDetail: true,
-                clusterID: task.clusterID
-              });
-              this.handleStartLog(task && task.taskID);
-              this.cancelAddCluster();
-              this.loadKubernetesCluster(task);
+                currentClusterID: task.clusterID
+              };
+              this.handleOk(task, upDateInfo);
             }}
           />
         );
@@ -305,7 +304,7 @@ export default class EnterpriseClusters extends PureComponent {
         params: { eid, provider }
       },
       location: {
-        query: { clusterID: ID, updateKubernetes }
+        query: { clusterID, updateKubernetes }
       }
     } = this.props;
     const {
@@ -316,7 +315,7 @@ export default class EnterpriseClusters extends PureComponent {
       showTaskDetail,
       lastTask,
       linkedClusters,
-      clusterID
+      currentClusterID
     } = this.state;
     const nextDisable = selectClusterID === '';
 
@@ -375,7 +374,7 @@ export default class EnterpriseClusters extends PureComponent {
             linkedClusters={linkedClusters}
             showBuyClusterConfig={this.showBuyClusterConfig}
             updateKubernetes={updateKubernetes}
-            updateKubernetesClusterID={ID}
+            updateKubernetesClusterID={clusterID}
           />
           {showBuyClusterConfig && this.renderCreateClusterShow()}
           <Col style={{ textAlign: 'center', marginTop: '32px' }} span={24}>
@@ -392,7 +391,7 @@ export default class EnterpriseClusters extends PureComponent {
               eid={eid}
               selectProvider={provider}
               taskID={lastTask.taskID}
-              clusterID={clusterID}
+              clusterID={currentClusterID}
             />
           )}
         </Card>

--- a/src/pages/AddCluster/KClusterList/index.js
+++ b/src/pages/AddCluster/KClusterList/index.js
@@ -34,7 +34,6 @@ export default class EnterpriseClusters extends PureComponent {
     const adminer = userUtil.isCompanyAdmin(user);
     this.state = {
       adminer,
-      isInitializeClusterVersion: false,
       showBuyClusterConfig: false,
       k8sClusters: [],
       loading: true,
@@ -73,8 +72,7 @@ export default class EnterpriseClusters extends PureComponent {
   };
   selectCluster = row => {
     this.setState({
-      selectClusterID: row.clusterID,
-      isInitializeClusterVersion: row.can_init
+      selectClusterID: row.clusterID
     });
   };
 
@@ -303,19 +301,6 @@ export default class EnterpriseClusters extends PureComponent {
   };
   render() {
     const {
-      k8sClusters,
-      showBuyClusterConfig,
-      loading,
-      isInitializeClusterVersion,
-      selectClusterID,
-      showTaskDetail,
-      lastTask,
-      linkedClusters,
-      clusterID
-    } = this.state;
-    const isSelectClusterID = selectClusterID === '';
-    const nextDisable = isSelectClusterID || !isInitializeClusterVersion;
-    const {
       match: {
         params: { eid, provider }
       },
@@ -323,6 +308,18 @@ export default class EnterpriseClusters extends PureComponent {
         query: { clusterID: ID, updateKubernetes }
       }
     } = this.props;
+    const {
+      k8sClusters,
+      showBuyClusterConfig,
+      loading,
+      selectClusterID,
+      showTaskDetail,
+      lastTask,
+      linkedClusters,
+      clusterID
+    } = this.state;
+    const nextDisable = selectClusterID === '';
+
     let title = 'Kubernetes 集群列表';
     switch (provider) {
       case 'ack':
@@ -340,6 +337,16 @@ export default class EnterpriseClusters extends PureComponent {
       default:
         title += `(不支持的驱动类型: ${provider})`;
     }
+    const nextStepBtn = (
+      <Button
+        style={{ marginLeft: '16px' }}
+        type="primary"
+        onClick={this.startInit}
+        disabled={nextDisable}
+      >
+        下一步
+      </Button>
+    );
     return (
       <PageHeaderLayout
         title="添加集群"
@@ -374,30 +381,9 @@ export default class EnterpriseClusters extends PureComponent {
           <Col style={{ textAlign: 'center', marginTop: '32px' }} span={24}>
             <Button onClick={this.preStep}>上一步</Button>
             {nextDisable ? (
-              <Tooltip
-                title={
-                  isSelectClusterID
-                    ? '请选择需要初始化的集群'
-                    : '当前集群版本无法继续初始化，初始化Rainbond支持的版本为1.16.x-1.19.x'
-                }
-              >
-                <Button
-                  style={{ marginLeft: '16px' }}
-                  type="primary"
-                  onClick={this.startInit}
-                  disabled={nextDisable}
-                >
-                  下一步
-                </Button>
-              </Tooltip>
+              <Tooltip title="请选择需要初始化的集群">{nextStepBtn}</Tooltip>
             ) : (
-              <Button
-                style={{ marginLeft: '16px' }}
-                type="primary"
-                onClick={this.startInit}
-              >
-                下一步
-              </Button>
+              nextStepBtn
             )}
           </Col>
           {showTaskDetail && lastTask && (


### PR DESCRIPTION
1、To solve the problem ：Obtain officially supported entry and can view log after failure
2、solution ：ClusterID field can be used to view user logs after failure to create QR code
Encapsulated cluster creation progress popup
3、test results : Obtain officially supported entry and can view log after failure
![image](https://user-images.githubusercontent.com/32888522/126441205-c6bb086e-9d07-4752-9874-e6605597e63d.png)
![image](https://user-images.githubusercontent.com/32888522/126467982-0f20f6f3-2761-44d6-8f67-9720dbc9ac9d.png)
