### PR TITLE
Fix the Apply template name validation

### DIFF
--- a/src/components/CreateAppModels/index.js
+++ b/src/components/CreateAppModels/index.js
@@ -489,6 +489,11 @@ class CreateAppModels extends PureComponent {
                     {
                       max: 32,
                       message: '最大长度32位'
+                    },
+                    {
+                      pattern: /^[a-z0-9A-Z\u4e00-\u9fa5]([a-zA-Z0-9_\-\u4e00-\u9fa5]*[a-z0-9A-Z\u4e00-\u9fa5])?$/,
+                      message:
+                        '只支持中文、字母、数字和-_组合，并且必须以中文、字母、数字开始和结束'
                     }
                   ]
                 })(<Input placeholder="请输入名称" />)}


### PR DESCRIPTION
Name verification: Supports only letters, digits, and hyphens (-) and must start and end with a letter or digit
![image](https://user-images.githubusercontent.com/32888522/128655839-e58d89bd-c471-4f16-83e1-0415d553a26a.png)
