### PR TITLE
Fix the Verify the configuration file name

### DIFF
--- a/src/components/AddStorage/index.js
+++ b/src/components/AddStorage/index.js
@@ -62,6 +62,10 @@ export default class AddVolumes extends PureComponent {
                   message: '请输入配置文件名称'
                 },
                 {
+                  pattern: /^[^\s]*$/,
+                  message: '禁止输入空格'
+                },
+                {
                   max: 30,
                   message: '最大长度30位'
                 }
@@ -80,6 +84,10 @@ export default class AddVolumes extends PureComponent {
                 {
                   required: true,
                   message: '请输入配置文件挂载路径'
+                },
+                {
+                  pattern: /^[^\s]*$/,
+                  message: '禁止输入空格'
                 },
                 {
                   max: 255,

--- a/src/components/CodeMirrorForm/index.js
+++ b/src/components/CodeMirrorForm/index.js
@@ -87,6 +87,14 @@ class CodeMirrorForm extends PureComponent {
       };
     }
   };
+  checkValue = (_, value, callback) => {
+    const { message } = this.props;
+    if (value === '' || !value || (value && value.trim() === '')) {
+      callback(message);
+      return;
+    }
+    callback();
+  };
 
   render() {
     const {
@@ -174,7 +182,7 @@ class CodeMirrorForm extends PureComponent {
       >
         {getFieldDecorator(name, {
           initialValue: data || '',
-          rules: [{ required: true, message }]
+          rules: [{ required: true, validator: this.checkValue }]
         })(<CodeMirror options={options} ref={this.saveRef} />)}
         {amplifications}
         {isHeader && (


### PR DESCRIPTION
修复问题：挂载配置文件时，文件名应不能有空格，缺乏校验
修复方式：增加pattern 校验
![image](https://user-images.githubusercontent.com/32888522/129019969-f6598a56-b6fb-492b-ba59-b4e2aba2213f.png)
