### PR TITLE
feat: add /cli-auth page for CLI browser login

### DIFF
--- a/config/router.config.js
+++ b/config/router.config.js
@@ -53,6 +53,13 @@ export default [
         name: 'Invite',
         authority: ['admin', 'user'],
       },
+      // CLI 授权（rainbond-skills install.sh 浏览器回调登录）
+      {
+        path: '/cli-auth',
+        component: './CliAuth',
+        name: 'CliAuth',
+        authority: ['admin', 'user'],
+      },
       // 应用市场安装
       {
         path: '/marketplace/install/:appId',

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -17,6 +17,7 @@ import login from './en-US/login'
 import versionUpdata from './en-US/versionUpdata'
 import explore from './en-US/explore'
 import resource from './en-US/resource'
+import cliAuth from './en-US/cliAuth'
 
 export default {
   'navBar.lang': 'lang',
@@ -42,5 +43,6 @@ export default {
   ...login,
   ...versionUpdata,
   ...explore,
-  ...resource
+  ...resource,
+  ...cliAuth
 };

--- a/src/locales/en-US/cliAuth.js
+++ b/src/locales/en-US/cliAuth.js
@@ -1,0 +1,21 @@
+const cliAuth = {
+  'cliAuth.title': 'Authorize Command Line Tool',
+  'cliAuth.description':
+    'The local rainbond-skills installer (Codex / Claude Code) is requesting your current login credentials to configure Rainbond MCP access.',
+  'cliAuth.warning.title': 'Confirm you started this installation',
+  'cliAuth.warning.detail':
+    'Clicking the button below sends your account JWT to the local callback address. It will only be used by the command line on this machine. Do not perform this on a public computer.',
+  'cliAuth.field.user': 'Current account',
+  'cliAuth.field.callback': 'Callback URL',
+  'cliAuth.button.authorize': 'Authorize and send token',
+  'cliAuth.invalid.title': 'Invalid authorization request',
+  'cliAuth.invalid.subtitle':
+    'Callback URL is not allowed (only 127.0.0.1 loopback callbacks are accepted). Please rerun the installer in your terminal.',
+  'cliAuth.done.title': 'Authorization complete',
+  'cliAuth.done.subtitle':
+    'Credentials have been sent to the local CLI. You can close this tab and return to your terminal.',
+  'cliAuth.error.noToken':
+    'No login token detected. Please sign in again and retry.',
+};
+
+export default cliAuth;

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -17,6 +17,7 @@ import login from './zh-CN/login'
 import versionUpdata from './zh-CN/versionUpdata'
 import explore from './zh-CN/explore'
 import resource from './zh-CN/resource'
+import cliAuth from './zh-CN/cliAuth'
 export default {
   'navBar.lang': '语言',
   'layout.user.link.help': '帮助',
@@ -41,5 +42,6 @@ export default {
   ...login,
   ...versionUpdata,
   ...explore,
-  ...resource
+  ...resource,
+  ...cliAuth
 };

--- a/src/locales/zh-CN/cliAuth.js
+++ b/src/locales/zh-CN/cliAuth.js
@@ -1,0 +1,21 @@
+const cliAuth = {
+  'cliAuth.title': '授权命令行工具',
+  'cliAuth.description':
+    '本地的 rainbond-skills 安装脚本（Codex / Claude Code）请求获取你当前的登录凭证，用于配置 Rainbond MCP 接入。',
+  'cliAuth.warning.title': '请确认这是你本人发起的安装',
+  'cliAuth.warning.detail':
+    '点击下方按钮后，浏览器会把当前账号的 JWT 发送到本机回调地址，仅用于本机命令行接入 Rainbond MCP。请勿在公共电脑上完成此操作。',
+  'cliAuth.field.user': '当前账号',
+  'cliAuth.field.callback': '回调地址',
+  'cliAuth.button.authorize': '授权并发送凭证',
+  'cliAuth.invalid.title': '授权请求无效',
+  'cliAuth.invalid.subtitle':
+    '回调地址不在允许范围（仅允许 127.0.0.1 本机回调）。请在终端重新运行安装脚本。',
+  'cliAuth.done.title': '授权完成',
+  'cliAuth.done.subtitle':
+    '凭证已发送到本机命令行，可关闭此页面回到终端继续。',
+  'cliAuth.error.noToken':
+    '未检测到登录凭证，请重新登录后再试。',
+};
+
+export default cliAuth;

--- a/src/pages/CliAuth/index.js
+++ b/src/pages/CliAuth/index.js
@@ -1,0 +1,169 @@
+/* eslint-disable compat/compat */
+import { Alert, Button, Card, Spin, Typography } from 'antd';
+import { connect } from 'dva';
+import React, { Component } from 'react';
+import { FormattedMessage, formatMessage } from 'umi';
+import cookie from '../../utils/cookie';
+import styles from './index.less';
+
+const { Paragraph, Text } = Typography;
+
+const CALLBACK_PATTERN = /^http:\/\/127\.0\.0\.1:\d{2,5}(\/[\w\-./]*)?$/;
+
+@connect(({ user, loading }) => ({
+  currentUser: user.currentUser,
+  loading: loading.effects['user/fetchCurrent'],
+}))
+export default class CliAuth extends Component {
+  constructor(props) {
+    super(props);
+    const params = new URLSearchParams(props.location.search);
+    this.state = {
+      callback: params.get('callback') || '',
+      state: params.get('state') || '',
+      status: 'idle',
+      errorMessage: '',
+    };
+  }
+
+  componentDidMount() {
+    const { dispatch, currentUser } = this.props;
+    if (!currentUser) {
+      dispatch({ type: 'user/fetchCurrent' });
+    }
+  }
+
+  isCallbackValid() {
+    const { callback } = this.state;
+    return CALLBACK_PATTERN.test(callback);
+  }
+
+  handleAuthorize = () => {
+    const { callback, state } = this.state;
+    const token = cookie.get('token');
+    if (!token) {
+      this.setState({
+        status: 'error',
+        errorMessage: formatMessage({ id: 'cliAuth.error.noToken' }),
+      });
+      return;
+    }
+    this.setState({ status: 'sending', errorMessage: '' });
+
+    fetch(callback, {
+      method: 'POST',
+      mode: 'no-cors',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, state }),
+    })
+      .then(() => {
+        this.setState({ status: 'done' });
+      })
+      .catch(err => {
+        this.setState({
+          status: 'error',
+          errorMessage: (err && err.message) || String(err),
+        });
+      });
+  };
+
+  renderInvalid() {
+    return (
+      <Alert
+        type="error"
+        showIcon
+        message={<FormattedMessage id="cliAuth.invalid.title" />}
+        description={<FormattedMessage id="cliAuth.invalid.subtitle" />}
+      />
+    );
+  }
+
+  renderDone() {
+    return (
+      <Alert
+        type="success"
+        showIcon
+        message={<FormattedMessage id="cliAuth.done.title" />}
+        description={<FormattedMessage id="cliAuth.done.subtitle" />}
+      />
+    );
+  }
+
+  renderForm() {
+    const { currentUser } = this.props;
+    const { callback, status, errorMessage } = this.state;
+    return (
+      <Card
+        title={<FormattedMessage id="cliAuth.title" />}
+        bordered={false}
+        className={styles.card}
+      >
+        <Paragraph>
+          <FormattedMessage id="cliAuth.description" />
+        </Paragraph>
+
+        <Alert
+          type="warning"
+          showIcon
+          message={<FormattedMessage id="cliAuth.warning.title" />}
+          description={<FormattedMessage id="cliAuth.warning.detail" />}
+          style={{ marginBottom: 16 }}
+        />
+
+        <Paragraph>
+          <Text strong>
+            <FormattedMessage id="cliAuth.field.user" />
+          </Text>
+          {`：${(currentUser && currentUser.nick_name) || '-'}`}
+        </Paragraph>
+        <Paragraph>
+          <Text strong>
+            <FormattedMessage id="cliAuth.field.callback" />
+          </Text>
+          {`：`}
+          <Text code>{callback}</Text>
+        </Paragraph>
+
+        {errorMessage && (
+          <Alert
+            type="error"
+            showIcon
+            message={errorMessage}
+            style={{ marginBottom: 16 }}
+          />
+        )}
+
+        <Button
+          type="primary"
+          loading={status === 'sending'}
+          onClick={this.handleAuthorize}
+        >
+          <FormattedMessage id="cliAuth.button.authorize" />
+        </Button>
+      </Card>
+    );
+  }
+
+  render() {
+    const { loading } = this.props;
+    const { status } = this.state;
+
+    if (!this.isCallbackValid()) {
+      return <div className={styles.wrap}>{this.renderInvalid()}</div>;
+    }
+
+    if (loading) {
+      return (
+        <div className={styles.wrap}>
+          <Spin />
+        </div>
+      );
+    }
+
+    if (status === 'done') {
+      return <div className={styles.wrap}>{this.renderDone()}</div>;
+    }
+
+    return <div className={styles.wrap}>{this.renderForm()}</div>;
+  }
+}

--- a/src/pages/CliAuth/index.less
+++ b/src/pages/CliAuth/index.less
@@ -1,0 +1,10 @@
+.wrap {
+  max-width: 640px;
+  margin: 64px auto;
+  padding: 0 24px;
+}
+
+.card {
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  border-radius: 4px;
+}


### PR DESCRIPTION
Render an authorization page used by rainbond-skills install.sh to obtain the current user's JWT through a loopback callback. The page validates the callback against 127.0.0.1, reuses the existing SecurityLayout login redirect when the user is signed out, and POSTs the cookie-stored JWT plus a state nonce back to the local CLI.