### PR TITLE
fix: use CORS mode for CLI callback fetch

### DIFF
--- a/src/pages/CliAuth/index.js
+++ b/src/pages/CliAuth/index.js
@@ -52,11 +52,14 @@ export default class CliAuth extends Component {
 
     fetch(callback, {
       method: 'POST',
-      mode: 'no-cors',
+      mode: 'cors',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ token, state }),
     })
-      .then(() => {
+      .then(resp => {
+        if (!resp.ok) {
+          throw new Error(`callback ${resp.status}`);
+        }
         this.setState({ status: 'done' });
       })
       .catch(err => {


### PR DESCRIPTION
Sending the JWT to the loopback callback with mode: 'no-cors' prevents the browser from issuing a Private Network Access preflight, so Chrome refuses the request from a public-IP origin to 127.0.0.1. Switch to mode: 'cors' so the preflight runs and the loopback server can opt in via Access-Control-Allow-Private-Network.