### PR TITLE
fix(agent): reset local conversation when route's team changes

### DIFF
--- a/src/models/agent.js
+++ b/src/models/agent.js
@@ -44,6 +44,7 @@ const {
   defaultCompactionState,
 } = require('./agentCompactionReducer');
 const { formatToolLabel } = require('../utils/agentToolLabels');
+const { shouldResetOnTeamSwitch } = require('./agentTeamSwitch');
 
 const { extractWorkflowState } = agentWorkflowState;
 
@@ -799,6 +800,20 @@ export default {
       const nextSignature = getAgentContextSignature(context);
       const currentSignature = state.lastContextSignature || '';
       const isChanged = !!currentSignature && currentSignature !== nextSignature;
+
+      // See agentTeamSwitch.shouldResetOnTeamSwitch: when the route's
+      // team changes while a live conversation exists, drop the local
+      // session anchor so the next sendMessage lets the backend's
+      // idempotent createSession produce / fetch the right session for
+      // the new team. Without this the old conversationId travels with
+      // the new team headers and the backend (tenant-scoped) returns
+      // "Session not found".
+      const resetOnTeamSwitch = shouldResetOnTeamSwitch({
+        previousContext: state.context,
+        nextContext: context,
+        conversationId: state.conversationId,
+      });
+
       const nextMessages = isChanged
         ? state.messages.concat(
             createMessage(
@@ -814,14 +829,36 @@ export default {
         currentSignature !== nextSignature ||
         JSON.stringify(state.context || {}) !== JSON.stringify(context || {})
       ) {
+        const patch = {
+          context,
+          lastContextSignature: nextSignature,
+          messages: resetOnTeamSwitch ? [] : nextMessages,
+          updatedAt: Date.now(),
+        };
+        if (resetOnTeamSwitch) {
+          patch.conversationId = 'global-default';
+          patch.pendingApproval = null;
+          patch.activeRunId = '';
+          patch.lastEventSequence = 0;
+          patch.workflowState = null;
+          patch.structuredResult = null;
+          patch.sessionPendingApprovals = [];
+          patch.draft = '';
+          patch.lastError = '';
+          patch.pendingMutationTool = '';
+          patch.pendingMutationRoute = '';
+          patch.pendingMutationNavigationKey = '';
+          patch.pendingMutationRefreshKey = '';
+          patch.pendingMutationRefreshMode = '';
+          patch.lastMutationResult = null;
+          patch.lastMutationRunId = '';
+          patch.runConflict = null;
+          patch.pendingDraft = '';
+          patch.pendingDraftMode = '';
+        }
         yield put({
           type: 'saveState',
-          payload: {
-            context,
-            lastContextSignature: nextSignature,
-            messages: nextMessages,
-            updatedAt: Date.now(),
-          },
+          payload: patch,
         });
       }
     },

--- a/src/models/agentTeamSwitch.js
+++ b/src/models/agentTeamSwitch.js
@@ -1,0 +1,39 @@
+// Pure helper for the team-switch reset decision used by agent.syncContext.
+//
+// Backend sessions are persisted per (tenant, user). A session created
+// while the user was on team A is invisible to a request that resolves
+// the actor to team B; holding the old conversationId across that
+// transition surfaces as "Session not found" on the next sendMessage.
+//
+// Returning true tells the saga to drop the local session anchor so the
+// next sendMessage falls through ensureSession and lets the backend's
+// idempotent createSession produce or fetch the right session for the
+// new team.
+//
+// The first context sync after hydration (previousTeam is empty) is
+// deliberately NOT treated as a switch — it is the initial population,
+// not a transition. Likewise, when there is no live conversation yet
+// (conversationId is the 'global-default' sentinel or missing), nothing
+// needs resetting.
+function shouldResetOnTeamSwitch({
+  previousContext,
+  nextContext,
+  conversationId,
+} = {}) {
+  const previousTeam = (previousContext || {}).teamName || '';
+  const nextTeam = (nextContext || {}).teamName || '';
+  if (!previousTeam) {
+    return false;
+  }
+  if (previousTeam === nextTeam) {
+    return false;
+  }
+  if (!conversationId || conversationId === 'global-default') {
+    return false;
+  }
+  return true;
+}
+
+module.exports = {
+  shouldResetOnTeamSwitch,
+};

--- a/src/models/agentTeamSwitch.node.test.js
+++ b/src/models/agentTeamSwitch.node.test.js
@@ -1,0 +1,67 @@
+const assert = require('assert');
+
+const { shouldResetOnTeamSwitch } = require('./agentTeamSwitch');
+
+// Case 1 — team changes with a live conversation: reset.
+{
+  const got = shouldResetOnTeamSwitch({
+    previousContext: { teamName: 'dhn9y6sk' },
+    nextContext: { teamName: 'c45s8exn' },
+    conversationId: 'cs_1778517815620_1',
+  });
+  assert.strictEqual(got, true, 'team switch with live conversation should reset');
+}
+
+// Case 2 — same team: do not reset.
+{
+  const got = shouldResetOnTeamSwitch({
+    previousContext: { teamName: 'dhn9y6sk' },
+    nextContext: { teamName: 'dhn9y6sk' },
+    conversationId: 'cs_real',
+  });
+  assert.strictEqual(got, false, 'same team should not reset');
+}
+
+// Case 3 — initial sync (no previous team yet): do not reset.
+{
+  const got = shouldResetOnTeamSwitch({
+    previousContext: {},
+    nextContext: { teamName: 'c45s8exn' },
+    conversationId: 'cs_real',
+  });
+  assert.strictEqual(got, false, 'initial population is not a transition');
+}
+
+// Case 4 — team switch but no live conversation: do not reset.
+{
+  const got = shouldResetOnTeamSwitch({
+    previousContext: { teamName: 'dhn9y6sk' },
+    nextContext: { teamName: 'c45s8exn' },
+    conversationId: 'global-default',
+  });
+  assert.strictEqual(got, false, 'no live conversation means nothing to reset');
+}
+
+// Case 5 — team switch and conversationId missing: do not reset.
+{
+  const got = shouldResetOnTeamSwitch({
+    previousContext: { teamName: 'a' },
+    nextContext: { teamName: 'b' },
+    conversationId: '',
+  });
+  assert.strictEqual(got, false, 'empty conversationId means nothing to reset');
+}
+
+// Case 6 — undefined inputs are tolerated and resolve to false.
+{
+  const got = shouldResetOnTeamSwitch({});
+  assert.strictEqual(got, false, 'undefined inputs should yield false');
+}
+
+// Case 7 — no-arg invocation is tolerated.
+{
+  const got = shouldResetOnTeamSwitch();
+  assert.strictEqual(got, false, 'no-arg invocation should yield false');
+}
+
+console.log('agentTeamSwitch: 7 cases passed');


### PR DESCRIPTION
Backend sessions are persisted per (tenant, user). After the copilot backend's tenant resolution started honoring the underscore-named X_TEAM_NAME header, sessions became actually team-scoped — a session created while the user was on team A is invisible to the next request that resolves the actor to team B. Holding the old conversationId across a UI team switch then surfaces as "Session not found" on the next sendMessage.

In syncContext, when the route's team changes while a live conversation exists, drop the local session anchor (conversationId, messages, run state, pending mutations). The next sendMessage falls through ensureSession which lets the backend's idempotent createSession produce or fetch the right session for the new team — no second-round trip needed up front.

Decision extracted to agentTeamSwitch.shouldResetOnTeamSwitch for testability; first-sync-after-hydration and same-team navigations are intentionally not treated as transitions.