### PR TITLE
fix(agent-host): targetRefToKey reads service_id/app_id/team_name by …

### DIFF
--- a/src/components/AgentHost/autoApprovalPolicy.js
+++ b/src/components/AgentHost/autoApprovalPolicy.js
@@ -59,8 +59,22 @@ function clearPolicies() {
 }
 
 function targetRefToKey(targetRef) {
-  if (!targetRef || !targetRef.kind || !targetRef.id) return null;
-  return `${targetRef.kind}:${targetRef.id}`;
+  if (!targetRef || !targetRef.kind) return null;
+  // Server emits { kind, service_id, service_alias, app_id, team_name, ... }
+  // (see rainbond-copilot/src/server/services/mutation-navigation-ref.ts).
+  // It does NOT include a generic `id` field, so the previous
+  // `targetRef.id` read always returned undefined and the "记住选择"
+  // policy entries showed up as `service:undefined` / `app:undefined`,
+  // never matching subsequent approvals. Pick the right id by kind.
+  let id = null;
+  if (targetRef.kind === 'service') {
+    id = targetRef.service_id || targetRef.service_alias;
+  } else if (targetRef.kind === 'app') {
+    id = targetRef.app_id;
+  } else if (targetRef.kind === 'team') {
+    id = targetRef.team_name;
+  }
+  return id ? `${targetRef.kind}:${id}` : null;
 }
 
 function policyMatches(policy, ctx) {
@@ -93,6 +107,7 @@ function matches(ctx) {
 
 module.exports = {
   STORAGE_KEY,
+  targetRefToKey,
   getPolicies,
   addPolicy,
   removePolicy,

--- a/src/components/AgentHost/autoApprovalPolicy.node.test.js
+++ b/src/components/AgentHost/autoApprovalPolicy.node.test.js
@@ -51,7 +51,7 @@ test('session-target matches by targetKey', () => {
     matches({
       risk: 'low',
       skillId: 'any',
-      targetRef: { kind: 'service', id: 's1' },
+      targetRef: { kind: 'service', service_id: 's1' },
     }),
     true
   );
@@ -59,7 +59,7 @@ test('session-target matches by targetKey', () => {
     matches({
       risk: 'low',
       skillId: 'any',
-      targetRef: { kind: 'service', id: 's2' },
+      targetRef: { kind: 'service', service_id: 's2' },
     }),
     false
   );
@@ -75,7 +75,7 @@ test('session-target-op requires both targetKey and skillId match', () => {
     matches({
       risk: 'low',
       skillId: 'rainbond_restart',
-      targetRef: { kind: 'service', id: 's1' },
+      targetRef: { kind: 'service', service_id: 's1' },
     }),
     true
   );
@@ -83,7 +83,7 @@ test('session-target-op requires both targetKey and skillId match', () => {
     matches({
       risk: 'low',
       skillId: 'rainbond_other',
-      targetRef: { kind: 'service', id: 's1' },
+      targetRef: { kind: 'service', service_id: 's1' },
     }),
     false
   );
@@ -132,7 +132,7 @@ test('multiple policies: any match wins', () => {
     matches({
       risk: 'low',
       skillId: 'restart',
-      targetRef: { kind: 'service', id: 'other' },
+      targetRef: { kind: 'service', service_id: 'other' },
     }),
     true
   );

--- a/src/components/AgentHost/index.js
+++ b/src/components/AgentHost/index.js
@@ -210,7 +210,7 @@ class ApprovalMessageCard extends PureComponent {
   renderNormalRiskActions() {
     const { approval, isSending, onDecision } = this.props;
     const targetRef = approval.targetRef || null;
-    const targetKey = targetRef ? `${targetRef.kind}:${targetRef.id}` : null;
+    const targetKey = autoApprovalPolicy.targetRefToKey(targetRef);
     const targetLabel = targetRef
       ? targetRef.kind === 'service' ? '该组件'
         : targetRef.kind === 'app' ? '该应用'


### PR DESCRIPTION
…kind

The auto-approval policy panel was storing entries as 'service:undefined' / 'app:undefined' because targetRefToKey expected a generic targetRef.id field that the backend never sends. The actual payload from copilot-controller's mutation-navigation-ref carries service_id / service_alias / app_id / team_name keyed by kind. Pick the right field per kind and fall through to null when none is available; export the helper so AgentHost/index.js can drop its duplicate inline implementation. Update the node test fixture from { kind, id } to the real shape so the contract stays honest.