### PR TITLE
fix: trust empty platform plugin list instead of falling back

### DIFF
--- a/src/pages/Extension/pluginCapacity/pluginTable.js
+++ b/src/pages/Extension/pluginCapacity/pluginTable.js
@@ -183,7 +183,9 @@ class Index extends PureComponent {
                 region_name: regionName,
             },
             callback: res => {
-                if (res && res.list && res.list.length > 0) {
+                // 接口正常返回数组就信任它，即便是空数组 (市场未匹配到任何插件 / 全被集群 arch 过滤)。
+                // 只有响应结构异常时才退化到"已安装列表"，避免空响应让整个列表闪烁消失。
+                if (res && Array.isArray(res.list)) {
                     this.setState({
                         pluginList: res.list,
                         loading: false


### PR DESCRIPTION
handlePluginList previously fell back to handleInstalledPluginList whenever res.list.length was 0, treating an empty market list the same as an HTTP error. With the new console arch-aware filter, a legitimate empty response is now possible (e.g. ARM cluster where no SKU matches), and combined with the 5s setInterval polling this caused the entire Extension page to flicker: every transient failure or empty response replaced the 9 market plugins with the (empty) installed-plugin list, then the next poll restored them.

Fix: only fall back when the response shape is unexpected. Array.isArray keeps both populated and empty arrays on the happy path; the existing handleError still covers real network/HTTP failures.