### PR TITLE
feat: add data-testid anchors for E2E create→build flow

### DIFF
--- a/src/components/CreateComponentModal/index.js
+++ b/src/components/CreateComponentModal/index.js
@@ -559,6 +559,7 @@ const CreateComponentModal = ({ visible, onCancel, dispatch, currentEnterprise, 
       iconSrc: ContainerIcon,
       title: formatMessage({ id: 'componentOverview.body.CreateComponentModal.from_image' }),
       key: 'image',
+      testid: 'rbd-create-from-image',
       hasSubMenu: true,
       iconColor: '#fa8c16',
     },
@@ -651,6 +652,7 @@ const CreateComponentModal = ({ visible, onCancel, dispatch, currentEnterprise, 
       iconSrc: ContainerIcon,
       title: formatMessage({ id: 'componentOverview.body.CreateComponentModal.container' }),
       key: 'custom',
+      testid: 'rbd-create-image-source-container',
       showForm: true,
       formType: 'docker',
       iconColor: '#fa8c16',
@@ -2083,7 +2085,7 @@ const CreateComponentModal = ({ visible, onCancel, dispatch, currentEnterprise, 
     if (currentView === 'form') {
       return (
         <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-          <Button type="primary" onClick={handleFooterSubmit} loading={false}>
+          <Button data-testid="rbd-comp-create-submit" type="primary" onClick={handleFooterSubmit} loading={false}>
             {formatMessage({ id: 'componentOverview.body.CreateComponentModal.confirm_create' })}
           </Button>
         </div>
@@ -2215,6 +2217,7 @@ const CreateComponentModal = ({ visible, onCancel, dispatch, currentEnterprise, 
     return (
       <div
         key={item.key}
+        data-testid={item.testid}
         className={className}
         onClick={() => !isDisplayOnly && handleItemClick(item)}
         onMouseEnter={(e) => {

--- a/src/pages/Create/create-check.js
+++ b/src/pages/Create/create-check.js
@@ -1774,6 +1774,7 @@ export default class CreateCheck extends React.Component {
             </Button>
           )}
           <Button
+            data-testid="rbd-build-wizard-next"
             type="primary"
             style={{ marginRight: '8px' }}
             onClick={this.handleConfigFile}
@@ -1806,6 +1807,7 @@ export default class CreateCheck extends React.Component {
             </Button>
           )}
           <Button
+            data-testid="rbd-build-wizard-next"
             type="primary"
             style={{ marginRight: '8px' }}
             onClick={this.handleConfigFile}
@@ -1847,6 +1849,7 @@ export default class CreateCheck extends React.Component {
     }
     return (
       <Result
+        data-testid="rbd-check-success"
         type="success"
         title={
           appDetail.service_source === 'third_party'

--- a/src/pages/Create/create-configFile.js
+++ b/src/pages/Create/create-configFile.js
@@ -358,6 +358,7 @@ export default class Index extends PureComponent {
               {formatMessage({id:'button.previous'})}
             </Button>
             <Button
+              data-testid="rbd-build-wizard-confirm"
               loading={buildAppsLoading}
               onClick={this.handleJumpNext}
               type="primary"

--- a/src/pages/TeamDashboard/TeamBasicInfo/index.js
+++ b/src/pages/TeamDashboard/TeamBasicInfo/index.js
@@ -311,6 +311,7 @@ export default class index extends Component {
     return (
       <div style={{ marginLeft: '0px' }}>
         <div
+          data-testid="rbd-app-create-btn"
           className={`${styles.teamHotAppItem} ${styles.addNewAppCard}`}
           onClick={() => {
             this.onJumpToWizard();


### PR DESCRIPTION
Merge the E2E test anchors (data-testid) into the mainline so the second-layer ui gate can rebuild the front-end from a ui PR branch and still locate elements via stable anchors. 9 lines, pure attribute additions across 4 files (CreateComponentModal / Create create-check & create-configFile / TeamBasicInfo); no logic, style, or copy changes. This also lets us retire the separate e2e-data-testid branch and the non-default dev-e2e-testid image.