### PR TITLE
ci: use pnpm test:ui-gate as the e2e gate test_cmd

### DIFF
--- a/.github/workflows/e2e-product-gate-trigger.yml
+++ b/.github/workflows/e2e-product-gate-trigger.yml
@@ -41,5 +41,5 @@ jobs:
             -f branch=main \
             -f who=console \
             -f ui_branch="$PR_BRANCH" \
-            -f test_cmd="playwright test tests/ui/login-render.spec.ts tests/ui/create-form-serialization.spec.ts tests/ui/component-ops-wiring.spec.ts tests/ui/key-page-render.spec.ts --workers=1"
+            -f test_cmd="pnpm test:ui-gate"
           echo "Dispatched E2E gate (ui) for ${PRODUCT_REPO} @ ${PR_SHA} (ui_branch ${PR_BRANCH})"


### PR DESCRIPTION
Fix the ui gate test_cmd. The previous direct "playwright test ..." failed with command not found (playwright lives in node_modules/.bin, not on PATH) inside the gate runner. Switch to "pnpm test:ui-gate" (added in the gate repo) so pnpm puts .bin on PATH, matching how console/region use pnpm scripts. The ui subset (4 specs, excluding flagship-journey) is now defined centrally in the gate repo.