### PR TITLE
feat(agent): prompt to update AI assistant plugin 

### DIFF
--- a/src/components/AgentHost/index.js
+++ b/src/components/AgentHost/index.js
@@ -1,5 +1,6 @@
 import React, { PureComponent, useEffect, useRef, useState } from 'react';
 import { Alert, Button, Dropdown, Icon, Input, Menu, Modal, Popover, Tag, message } from 'antd';
+import { routerRedux } from 'dva/router';
 import ReactMarkdown from 'react-markdown';
 import styles from './index.less';
 import * as autoApprovalPolicy from './autoApprovalPolicy';
@@ -515,7 +516,7 @@ function formatRelativeTime(iso) {
 export default class AgentHost extends PureComponent {
   constructor(props) {
     super(props);
-    this.state = { historyPopoverVisible: false };
+    this.state = { historyPopoverVisible: false, updateBannerDismissed: false };
     this.messagesRef = null;
     this.isAutoScrollEnabled = true;
     this.lastRenderedMessagesRef = null;
@@ -658,6 +659,25 @@ export default class AgentHost extends PureComponent {
         this.handleStopRun({ hideAfterAbort: true });
       },
     });
+  };
+
+  // 跳转到 AI 助手插件对应应用的升级页（复用平台既有升级流程），并关闭面板。
+  handleGoUpgrade = () => {
+    const { agent, dispatch } = this.props;
+    const update = (agent && agent.agentUpdate) || null;
+    if (!update || !update.appId || !update.teamName || !update.regionName) {
+      return;
+    }
+    const url = `/team/${update.teamName}/region/${update.regionName}/apps/${update.appId}/upgrade`;
+    if (dispatch) {
+      dispatch(routerRedux.push(url));
+      dispatch({ type: 'agent/hide' });
+    }
+  };
+
+  // 忽略本次更新提示（仅当前会话内生效，刷新后或下次有新版本会重新出现）。
+  handleDismissUpdateBanner = () => {
+    this.setState({ updateBannerDismissed: true });
   };
 
   handleDraftChange = event => {
@@ -1280,6 +1300,17 @@ export default class AgentHost extends PureComponent {
     const mode = (panelConfig && panelConfig.mode) || 'push';
     const isOverlay = mode === 'overlay';
 
+    // 插件更新提示：仅在确实可升级且跳转所需信息齐全、且未被本次会话忽略时展示。
+    const agentUpdate = (agent && agent.agentUpdate) || null;
+    const showUpdateBanner = !!(
+      agentUpdate &&
+      agentUpdate.upgradeable &&
+      agentUpdate.appId &&
+      agentUpdate.teamName &&
+      agentUpdate.regionName &&
+      !this.state.updateBannerDismissed
+    );
+
     return (
       <div className={styles.agentHost}>
         <div
@@ -1331,6 +1362,35 @@ export default class AgentHost extends PureComponent {
                 </button>
               </div>
             </div>
+
+            {showUpdateBanner && (
+              <div className={styles.updateBanner}>
+                <Icon type="arrow-up" className={styles.updateBannerIcon} />
+                <div className={styles.updateBannerText}>
+                  <span className={styles.updateBannerTitle}>AI 助手有新版本</span>
+                  <span className={styles.updateBannerVersion}>
+                    {(agentUpdate.installedVersion || '当前')}
+                    {' → '}
+                    {(agentUpdate.latestVersion || '最新')}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  className={styles.updateBannerButton}
+                  onClick={this.handleGoUpgrade}
+                >
+                  去更新
+                </button>
+                <button
+                  type="button"
+                  className={styles.updateBannerClose}
+                  aria-label="忽略更新提示"
+                  onClick={this.handleDismissUpdateBanner}
+                >
+                  <Icon type="close" />
+                </button>
+              </div>
+            )}
 
             <div className={styles.drawerBody}>
               <div

--- a/src/components/AgentHost/index.less
+++ b/src/components/AgentHost/index.less
@@ -299,6 +299,88 @@
   color: #8c8c8c;
 }
 
+// AI 助手插件更新提示条：窄面板内的紧凑非阻断 banner，沿用应用升级页的橙色视觉。
+.updateBanner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  // 上间距收紧、补足下间距，避免"上空下贴"；纯暖色块 + 投影让卡片浮起，
+  // 不让底部白色融进面板背景。
+  margin: 6px 12px 12px;
+  padding: 9px 10px;
+  border: 1px solid #ffd7c8;
+  border-left: 3px solid #ff7a2f;
+  border-radius: 10px;
+  background: #fff6ef;
+  box-shadow: 0 6px 16px rgba(255, 122, 47, 0.1);
+}
+
+.updateBannerIcon {
+  flex-shrink: 0;
+  color: #ff7a2f;
+  font-size: 16px;
+}
+
+.updateBannerText {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  line-height: 1.35;
+}
+
+.updateBannerTitle {
+  color: @heading-color;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.updateBannerVersion {
+  color: #c96a3a;
+  font-size: 12px;
+}
+
+.updateBannerButton {
+  flex-shrink: 0;
+  height: 26px;
+  padding: 0 12px;
+  border: none;
+  border-radius: 999px;
+  background: #ff7a2f;
+  color: #fff;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+
+  &:hover,
+  &:focus {
+    outline: none;
+    background: #ff8d4d;
+  }
+}
+
+.updateBannerClose {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: #b0772f;
+  cursor: pointer;
+  transition: background 0.2s ease;
+
+  &:hover,
+  &:focus {
+    outline: none;
+    background: rgba(255, 122, 47, 0.12);
+  }
+}
+
 .drawerBody {
   display: flex;
   flex-direction: column;

--- a/src/components/GlobalHeader/index.js
+++ b/src/components/GlobalHeader/index.js
@@ -392,6 +392,16 @@ class GlobalHeader extends PureComponent {
         return;
       }
 
+      // 复用已解析的区域列表，静默检测 AI 助手插件是否有可升级版本；
+      // 结果存入 agent model 的 agentUpdate，供入口红点与面板 banner 读取。
+      dispatch({
+        type: 'agent/fetchAgentUpdate',
+        payload: {
+          enterprise_id: enterpriseId,
+          region_names: uniqueRegionNames
+        }
+      });
+
       let pending = uniqueRegionNames.length;
       let successCount = 0;
       let pluginList = [];
@@ -1199,7 +1209,8 @@ class GlobalHeader extends PureComponent {
       collapsed,
       logo,
       enterprise,
-      agentVisible
+      agentVisible,
+      agentUpdate
     } = this.props;
     const {
       language,
@@ -1233,6 +1244,12 @@ class GlobalHeader extends PureComponent {
         agentAccess.is_open_source ||
         agentAccess.edition === 'open_source'
       )
+    );
+    // AI 助手有可升级版本时显示红点；与"企"角标互斥（开源受限态下不提示更新）。
+    const showAgentUpdateDot = !!(
+      agentUpdate &&
+      agentUpdate.upgradeable &&
+      !showAgentEnterpriseBadge
     );
 
     return (
@@ -1303,6 +1320,15 @@ class GlobalHeader extends PureComponent {
                   {showAgentEnterpriseBadge && (
                     <span className={styles.agentEntryBadge}>企</span>
                   )}
+                  {showAgentUpdateDot && (
+                    <span
+                      className={styles.agentEntryUpdateDot}
+                      title={formatMessage({
+                        id: 'GlobalHeader.agent.update.dot',
+                        defaultMessage: 'AI 助手有新版本可更新'
+                      })}
+                    />
+                  )}
                   <span className={styles.agentEntryIcon}>
                     <AgentEntryIcon />
                   </span>
@@ -1349,6 +1375,7 @@ export default connect(({ user, global, agent, teamControl }) => ({
   enterprise: global.enterprise,
   collapsed: global.collapsed,
   agentVisible: !!(agent && agent.visible),
+  agentUpdate: (agent && agent.agentUpdate) || null,
   pluginsList: teamControl.pluginsList,
   pluginsLoaded: teamControl.pluginsLoaded
 }))(GlobalHeader);

--- a/src/components/GlobalHeader/index.less
+++ b/src/components/GlobalHeader/index.less
@@ -494,6 +494,33 @@ i.trigger {
   pointer-events: none;
 }
 
+// AI 助手有新版本时的红点提示，复用 badge 的定位，缩小为纯圆点并带呼吸光晕。
+.agentEntryUpdateDot {
+  position: absolute;
+  top: -3px;
+  right: -2px;
+  width: 10px;
+  height: 10px;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  background: @error-color;
+  box-shadow: 0 0 0 0 rgba(252, 72, 27, 0.5);
+  pointer-events: none;
+  animation: agentEntryUpdatePulse 2s ease-out infinite;
+}
+
+@keyframes agentEntryUpdatePulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(252, 72, 27, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 6px rgba(252, 72, 27, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(252, 72, 27, 0);
+  }
+}
+
 .agentEntryIcon {
   display: inline-flex;
   align-items: center;

--- a/src/locales/en-US/menu.js
+++ b/src/locales/en-US/menu.js
@@ -95,6 +95,7 @@ const CustomFooter = {
   'GlobalHeader.agent.access.enterprise': 'Learn about Enterprise Edition',
   'GlobalHeader.agent.access.cancel': 'Got it',
   'GlobalHeader.agent.access.load_error': 'Failed to check AI assistant access. Please try again later.',
+  'GlobalHeader.agent.update.dot': 'A new version of AI Assistant is available',
   'GlobalHeader.agent.config.missing.title': 'AI assistant configuration is incomplete',
   'GlobalHeader.agent.config.missing.content': 'The AI assistant plugin is installed, but the API key is not configured yet. Complete the AI assistant configuration before using it.',
   'GlobalHeader.agent.config.missing.contact_admin': 'The AI assistant plugin is installed, but the API key is not configured yet. Please contact an enterprise administrator to complete the configuration.',

--- a/src/locales/zh-CN/menu.js
+++ b/src/locales/zh-CN/menu.js
@@ -97,6 +97,7 @@ const CustomFooter = {
   'GlobalHeader.agent.access.enterprise': '了解企业版',
   'GlobalHeader.agent.access.cancel': '我知道了',
   'GlobalHeader.agent.access.load_error': 'AI 助手权限检查失败，请稍后重试。',
+  'GlobalHeader.agent.update.dot': 'AI 助手有新版本可更新',
   'GlobalHeader.agent.config.missing.title': 'AI助手配置未完成',
   'GlobalHeader.agent.config.missing.content': '当前企业已安装 AI 助手插件，但尚未配置接口密钥。请先完成 AI 助手配置后再使用。',
   'GlobalHeader.agent.config.missing.contact_admin': '当前企业已安装 AI 助手插件，但尚未配置接口密钥，请联系企业管理员完成配置。',

--- a/src/models/agent.js
+++ b/src/models/agent.js
@@ -13,6 +13,8 @@ import {
   subscribeToActiveRun,
 } from '../services/agent';
 import { getAgentAccess } from '../services/agentAccess';
+import { getEnterprisePluginList } from '../services/api';
+import { isPluginBaseId } from '../utils/pluginArchUtils';
 import * as agentEventAdapter from '../services/agentEventAdapter';
 import {
   formatAgentContextMessage,
@@ -151,6 +153,9 @@ function stopAllCrossTabSubscriptions() {
 const defaultState = {
   hydrated: false,
   visible: false,
+  // AI 助手插件更新信息（来自 platform-plugins 接口的 rainbond-agent 条目）；
+  // null 表示无更新或尚未检测。结构见 fetchAgentUpdate effect。
+  agentUpdate: null,
   conversationId: 'global-default',
   messages: [],
   draft: '',
@@ -771,6 +776,66 @@ export default {
           callback(null, e);
         }
       }
+    },
+
+    // 检测 AI 助手插件（rainbond-agent）是否有可升级版本。
+    // 静默调用 platform-plugins 接口（showMessage/showLoading 关闭），失败即视为"无更新"，
+    // 绝不阻塞或干扰顶栏。命中第一个"已安装且可升级"的条目即记录其升级跳转所需信息。
+    *fetchAgentUpdate({ payload }, { call, put }) {
+      const enterpriseId = payload && payload.enterprise_id;
+      const regionNames = Array.isArray(payload && payload.region_names)
+        ? payload.region_names.filter(Boolean)
+        : [];
+
+      if (!enterpriseId || !regionNames.length) {
+        yield put({ type: 'saveAgentUpdate', payload: null });
+        return;
+      }
+
+      let agentEntry = null;
+      for (let i = 0; i < regionNames.length; i += 1) {
+        const regionName = regionNames[i];
+        let response = null;
+        try {
+          response = yield call(
+            getEnterprisePluginList,
+            { enterprise_id: enterpriseId, region_name: regionName },
+            () => {},
+            { showMessage: false, showLoading: false }
+          );
+        } catch (e) {
+          response = null;
+        }
+
+        const list = (response && response.list) || [];
+        const found = list.find(
+          item =>
+            isPluginBaseId(item, 'rainbond-agent') &&
+            item.installed === true &&
+            item.upgradeable === true
+        );
+        if (found) {
+          agentEntry = { ...found, region_name: regionName };
+          break;
+        }
+      }
+
+      if (!agentEntry) {
+        yield put({ type: 'saveAgentUpdate', payload: null });
+        return;
+      }
+
+      yield put({
+        type: 'saveAgentUpdate',
+        payload: {
+          upgradeable: true,
+          installedVersion: agentEntry.installed_version || '',
+          latestVersion: agentEntry.latest_version || '',
+          appId: agentEntry.app_id,
+          teamName: agentEntry.team_name || '',
+          regionName: agentEntry.region_name || ''
+        }
+      });
     },
 
     *hydrateSession({ payload }, { call, put }) {
@@ -1743,6 +1808,14 @@ export default {
         ...state,
         visible: true,
         updatedAt: Date.now(),
+      };
+    },
+
+    // 仅更新 agentUpdate，不动 updatedAt：避免触发 RootShell 基于 updatedAt 的上下文同步副作用。
+    saveAgentUpdate(state, { payload }) {
+      return {
+        ...state,
+        agentUpdate: payload || null,
       };
     },
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1512,12 +1512,15 @@ export async function deleteShellPod(params) {
   );
 }
 // 获取插件
-export async function getEnterprisePluginList(body, handleError) {
+// options 透传给 request（如 showMessage / showLoading），默认为空以保持既有调用方行为不变；
+// AI 助手更新检测以静默模式调用该接口（showMessage: false, showLoading: false）。
+export async function getEnterprisePluginList(body, handleError, options = {}) {
   return request(
     `${apiconfig.baseUrl}/console/enterprise/${body.enterprise_id}/regions/${body.region_name}/platform-plugins`,
     {
       method: 'get',
-      handleError
+      handleError,
+      ...options
     }
   );
 }


### PR DESCRIPTION
Surface plugin updates at point of use using the existing platform-plugins endpoint (installed_version / latest_version / upgradeable) — no backend change.

- GlobalHeader: silently detect rainbond-agent upgradeable across resolved regions; render a pulsing red dot on the AI assistant entry (mutually exclusive with the enterprise badge)
- AgentHost: non-blocking banner at the top of the panel showing the version delta, with the update action navigating to the app upgrade page and a dismiss action
- agent model: add agentUpdate state, fetchAgentUpdate effect (silent, fail-soft) and saveAgentUpdate reducer
- api: getEnterprisePluginList accepts optional request options for silent calls
- i18n: add GlobalHeader.agent.update.dot