### PR TITLE
fix(agent): use synchronous force-cancel for stop-and-send to avoid race

### DIFF
--- a/src/models/agent.js
+++ b/src/models/agent.js
@@ -1,6 +1,7 @@
 import { getDvaApp } from 'umi';
 import {
   abortAgentRun,
+  forceCancelAgentRun,
   cancelAgentSessionPending,
   clearAgentSession,
   clearAgentSessionRemote,
@@ -1302,9 +1303,15 @@ export default {
       });
 
       try {
-        yield call(abortAgentRun, { sessionId, runId });
+        // Force-cancel (not abort): synchronous server-side clear that runs
+        // the recovery truncation protocol and commits the terminal status
+        // before returning. Abort was 202-async — it only flipped status once
+        // a live executor reached a checkpoint, so a wedged/zombie run (e.g.
+        // its executor crashed) never went terminal and the sendMessage below
+        // 409'd forever. A 200 here means the foreign run is already terminal.
+        yield call(forceCancelAgentRun, { sessionId, runId });
       } catch (e) {
-        // Foreign-run abort failed (e.g. 500). Tear down the conflict
+        // Foreign-run force-cancel failed (e.g. 500). Tear down the conflict
         // UI so the user can decide their next move instead of being
         // stuck on the dialog. Do NOT auto-send their stashed draft —
         // the foreign run may still be alive server-side.
@@ -1323,9 +1330,9 @@ export default {
         return;
       }
 
-      // Abort returned 202 — the server has accepted the cancellation request.
-      // Stop watching the foreign run and send directly; waiting for an SSE
-      // terminal event is unreliable (stream may have dropped on refresh).
+      // force-cancel returned 200 — the foreign run is now terminal. Stop
+      // watching it and send directly; no need to wait for an SSE terminal
+      // event (stream may have dropped on refresh) and no 409 race remains.
       stopAllCrossTabSubscriptions();
       yield put({
         type: 'saveState',

--- a/src/services/agent.js
+++ b/src/services/agent.js
@@ -317,6 +317,25 @@ export async function abortAgentRun({ sessionId, runId } = {}) {
   return result;
 }
 
+// Synchronously force-clear a wedged/active run so the session unlocks
+// immediately. Unlike abortAgentRun (202 = accepted, run may still be
+// running for a while — or forever if its executor crashed), a 200 here
+// means the run is already terminal, so the next sendMessage will not 409.
+export async function forceCancelAgentRun({ sessionId, runId } = {}) {
+  if (!sessionId || !runId) {
+    throw new Error('sessionId and runId are required');
+  }
+  const result = await requestJsonAcceptStatuses(
+    `${await copilotApiBase()}/sessions/${encodeURIComponent(sessionId)}/runs/${encodeURIComponent(runId)}/force-cancel`,
+    {
+      method: 'POST',
+      headers: buildRequestHeaders(),
+    },
+    [200, 404]
+  );
+  return result;
+}
+
 export async function clearAgentSessionRemote(sessionId) {
   if (!sessionId) {
     throw new Error('sessionId is required');


### PR DESCRIPTION
The conflict panel's stop-and-send called abortAgentRun (202 async), then sent the stashed message immediately. A wedged/zombie foreign run never reached a terminal state, so the resend kept hitting 409. Add forceCancelAgentRun (POST /force-cancel, 200 = run already terminal) and use it in the stopAndSendMine effect; abortRun (same-window stop) is unchanged.