### PR TITLE
fix: dedupe build event logs replayed by websocket history

### DIFF
--- a/src/pages/Component/component/LogShow/index.js
+++ b/src/pages/Component/component/LogShow/index.js
@@ -26,6 +26,8 @@ class Index extends React.Component {
       dynamic: false
     };
     this.state.dockerprogress = new Map();
+    // 记录已渲染的无 id 日志行，避免 websocket 重放历史时重复追加
+    this.seenMessages = new Set();
   }
   componentDidMount() {
     this.loadEventLog();
@@ -63,9 +65,7 @@ class Index extends React.Component {
       callback: res => {
         if (res) {
           this.setState(
-            {
-              logs: res.list
-            },
+            this.mergeHistoryLogs(res.list),
             () => {
               if (showSocket) {
                 this.showSocket();
@@ -78,30 +78,59 @@ class Index extends React.Component {
       }
     });
   }
+  // 历史日志去重：HTTP 拉取的历史先登记到 dockerprogress / seenMessages，
+  // 后续 websocket 建连时服务端会把同一批历史重放一遍，靠这两份登记吸收掉
+  mergeHistoryLogs = list => {
+    const { dockerprogress } = this.state;
+    const logs = [];
+    (list || []).forEach(item => {
+      const progress = this.parseProgressMessage(item.message);
+      if (progress) {
+        if (dockerprogress.get(progress.id) === undefined) {
+          logs.push(item);
+        }
+        dockerprogress.set(progress.id, progress);
+        return;
+      }
+      if (!this.seenMessages.has(item.message)) {
+        this.seenMessages.add(item.message);
+        logs.push(item);
+      }
+    });
+    return { logs, dockerprogress };
+  };
+  parseProgressMessage = message => {
+    if (!message || message.indexOf('id') === -1) {
+      return null;
+    }
+    try {
+      const m = JSON.parse(message);
+      if (m && m.id !== undefined) {
+        return m;
+      }
+    } catch (err) {
+      // 非 JSON 进度消息，按普通日志处理
+    }
+    return null;
+  };
   handleMessage = data => {
     const logs = this.state.logs || [];
-    if (data.message.indexOf('id') !== -1) {
-      try {
-        const m = JSON.parse(data.message);
-        if (m && m.id !== undefined) {
-          const { dockerprogress } = this.state;
-          if (dockerprogress.get(m.id) !== undefined) {
-            dockerprogress.set(m.id, m);
-          } else {
-            dockerprogress.set(m.id, m);
-            logs.push(data);
-          }
-          this.setState({
-            dockerprogress,
-            logs,
-            dynamic: true
-          });
-          return;
-        }
-      } catch (err) {
+    const progress = this.parseProgressMessage(data.message);
+    if (progress) {
+      const { dockerprogress } = this.state;
+      if (dockerprogress.get(progress.id) === undefined) {
         logs.push(data);
       }
-    } else {
+      dockerprogress.set(progress.id, progress);
+      this.setState({
+        dockerprogress,
+        logs,
+        dynamic: true
+      });
+      return;
+    }
+    if (!this.seenMessages.has(data.message)) {
+      this.seenMessages.add(data.message);
       logs.push(data);
     }
     if (this.refs.box) {


### PR DESCRIPTION
## 问题

构建日志弹窗中日志整段重复：弹窗先通过 HTTP 拉取历史日志填充列表，随后建立 event_log websocket，而服务端在 websocket 建连时会把同一批历史消息重放一遍再接实时流。HTTP 加载的进度消息没有登记进 `dockerprogress` 去重 map，无 id 的普通行也没有任何去重，导致所有行重复出现一次（websocket 中途重连时还会再叠加）。

## 修复

- HTTP 历史加载时统一走 `mergeHistoryLogs`：带 id 的进度行登记进 `dockerprogress` 并按 id 去重，普通行登记进 `seenMessages` 集合
- `handleMessage` 复用同一套去重逻辑，websocket 重放的历史被原地吸收，进度行仍按 id 原地刷新

## 验证

- `yarn build` 编译通过（0 errors / 0 warnings）
- 配合 goodrain/rainbond 侧 builder 进度日志去重修复（2f63cb121）联调：服务端事件文件无重复行，弹窗不再出现整段重复