### PR TITLE
fix: improve Sentry API error grouping and add backend context tags

### DIFF
--- a/src/sentry.js
+++ b/src/sentry.js
@@ -3,13 +3,16 @@ import {
   buildIssueFingerprint,
   buildReadableErrorMessage,
   buildSentryTunnelUrl,
+  classifyHttpError,
+  extractResponseMetadata,
   getPathPattern,
   getSentryConfig,
   parseStackFrames,
   sanitizeObject,
   sanitizeStack,
   shouldPreferFetchTransport,
-  shouldReportRequestError
+  shouldReportRequestError,
+  shouldSuppressRequestError
 } from './sentryConfig';
 
 let initialized = false;
@@ -351,12 +354,21 @@ export function captureRequestError(error, options = {}) {
   if (!initialized || !shouldReportRequestError(error)) {
     return;
   }
+  if (shouldSuppressRequestError(error, options)) {
+    return;
+  }
   const response = error && error.response;
   const config = (error && error.config) || options || {};
   const status = response && response.status;
   const method = String(config.method || 'GET').toUpperCase();
   const route = getPathPattern(config.url);
   const responseData = (response && response.data) || {};
+
+  // Extract backend metadata for cross-referencing with console/region logs
+  const responseMeta = extractResponseMetadata(response);
+  const errorClass = classifyHttpError(error);
+  const businessCode = responseData && responseData.code;
+
   const requestContext = {
     method,
     url: getPathPattern(config.url),
@@ -367,8 +379,10 @@ export function captureRequestError(error, options = {}) {
     method,
     status: status || 'network',
     status_text: response && response.statusText,
-    business_code: responseData && responseData.code,
-    response_message: responseData && (responseData.msg || responseData.msg_show)
+    business_code: businessCode,
+    response_message: responseMeta.response_message,
+    request_id: responseMeta.request_id,
+    backend_error_class: errorClass
   };
   captureException(error, {
     errorSource: 'api',
@@ -377,13 +391,17 @@ export function captureRequestError(error, options = {}) {
     route,
     status: status || 'network',
     method,
-    fingerprint: ['rainbond-ui-api', String(status || 'network'), method, route || 'unknown endpoint'],
+    backendErrorClass: errorClass,
+    businessCode: businessCode || '',
     tags: {
       component: 'rainbond-ui',
       error_source: 'api',
       request_status: status || 'network',
       request_method: method,
-      route
+      route,
+      backend_error_class: errorClass,
+      business_code: businessCode ? String(businessCode) : '',
+      request_id: responseMeta.request_id
     },
     request: requestContext,
     api: apiContext,
@@ -392,8 +410,10 @@ export function captureRequestError(error, options = {}) {
       method,
       status,
       status_text: response && response.statusText,
-      business_code: responseData && responseData.code,
-      response_message: responseData && (responseData.msg || responseData.msg_show)
+      business_code: businessCode,
+      response_message: responseMeta.response_message,
+      request_id: responseMeta.request_id,
+      backend_error_class: errorClass
     }
   });
 }

--- a/src/sentryConfig.js
+++ b/src/sentryConfig.js
@@ -253,6 +253,78 @@ function shouldReportRequestError(error) {
   return error.response.status >= 500;
 }
 
+/**
+ * Classifies an HTTP error into a broad error class for Sentry grouping.
+ * Instead of grouping by endpoint (which over-splits during outages),
+ * group by the type of backend failure so a single outage creates one issue.
+ *
+ * Error classes:
+ *   - "network"     — no response at all (timeout, DNS, CORS, connection refused)
+ *   - "gateway"     — 502 Bad Gateway (upstream service down)
+ *   - "overloaded"  — 503 Service Unavailable (backend overloaded or deploying)
+ *   - "timeout"     — 504 Gateway Timeout
+ *   - "backend"     — 500 Internal Server Error (generic backend crash)
+ *   - "other"       — any other 5xx
+ */
+function classifyHttpError(error) {
+  if (!error || !error.response) {
+    return 'network';
+  }
+  const status = error.response.status;
+  if (status === 502) return 'gateway';
+  if (status === 503) return 'overloaded';
+  if (status === 504) return 'timeout';
+  if (status === 500) return 'backend';
+  return 'other';
+}
+
+/**
+ * Determines whether a request error is expected/transient and should be
+ * suppressed from Sentry. The UI already handles these gracefully via
+ * handleSpecialErrorCode or user-facing notifications, so reporting them
+ * creates noise without actionable signal.
+ *
+ * Suppressed conditions:
+ *   - Network errors (no response) where the caller has its own error handler
+ *   - 502/503/504 when the UI shows a user-facing notification
+ */
+function shouldSuppressRequestError(error, options) {
+  if (!error) return false;
+
+  const status = error.response && error.response.status;
+
+  // Suppress network errors when a custom error handler is provided
+  // (the caller is handling it gracefully)
+  if (!status && options && options.handleError) {
+    return true;
+  }
+
+  // Suppress 502/503/504 gateway errors — these are transient backend
+  // outages that the UI already shows via notification.warning in checkStatus
+  if (status === 502 || status === 503 || status === 504) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Extracts backend metadata from a response for Sentry tags/context.
+ * Pulls x-request-id, backend error code, and business code from
+ * the response so UI Sentry events can be cross-referenced with
+ * backend/console logs.
+ */
+function extractResponseMetadata(response) {
+  if (!response) return {};
+  const headers = response.headers || {};
+  const data = response.data || {};
+  return {
+    request_id: headers['x-request-id'] || headers['X-Request-Id'] || '',
+    backend_error_code: data.code || '',
+    response_message: data.msg_show || data.msg || ''
+  };
+}
+
 function shouldPreferFetchTransport(event) {
   return getErrorSource(event || {}) === 'api';
 }
@@ -417,7 +489,9 @@ function buildReadableErrorMessage(error, context) {
     const status = safeContext.status || (safeContext.tags && safeContext.tags.request_status) || 'Network';
     const method = normalizeMethod(safeContext.method || (safeContext.tags && safeContext.tags.request_method));
     const route = safeContext.route || (safeContext.tags && safeContext.tags.route) || 'unknown endpoint';
-    return `API ${status} ${method} ${route}`;
+    const errorClass = safeContext.backendErrorClass || (safeContext.tags && safeContext.tags.backend_error_class);
+    const classSuffix = errorClass && errorClass !== 'network' ? ` [${errorClass}]` : '';
+    return `API ${status} ${method} ${route}${classSuffix}`;
   }
 
   if (source === 'react_error_boundary') {
@@ -451,11 +525,19 @@ function buildIssueFingerprint(error, context, frames) {
 
   const source = getErrorSource(safeContext);
   if (source === 'api') {
+    // Group by error class + business_code instead of route.
+    // This prevents a single backend outage from creating one Sentry issue
+    // per API endpoint. All 500s from the same backend class group together,
+    // and all "network down" errors group together.
+    const rawStatus = safeContext.status || (safeContext.tags && safeContext.tags.request_status);
+    const errorClass = safeContext.backendErrorClass ||
+      (rawStatus === 'network' || rawStatus === 'Network' ? 'network' : classifyHttpError({ response: { status: rawStatus } }));
+    const businessCode = safeContext.businessCode || (safeContext.tags && safeContext.tags.business_code) || '';
+
     return [
       'rainbond-ui-api',
-      String(safeContext.status || (safeContext.tags && safeContext.tags.request_status) || 'network'),
-      normalizeMethod(safeContext.method || (safeContext.tags && safeContext.tags.request_method)),
-      safeContext.route || (safeContext.tags && safeContext.tags.route) || 'unknown endpoint'
+      String(errorClass),
+      businessCode ? String(businessCode) : 'no-code'
     ];
   }
 
@@ -474,6 +556,8 @@ module.exports = {
   buildIssueFingerprint,
   buildReadableErrorMessage,
   buildSentryTunnelUrl,
+  classifyHttpError,
+  extractResponseMetadata,
   getPathPattern,
   getSentryConfig,
   parseStackFrames,
@@ -481,5 +565,6 @@ module.exports = {
   sanitizeStack,
   sanitizeUrl,
   shouldPreferFetchTransport,
-  shouldReportRequestError
+  shouldReportRequestError,
+  shouldSuppressRequestError
 };

--- a/src/sentryConfig.node.test.js
+++ b/src/sentryConfig.node.test.js
@@ -3,6 +3,8 @@ const assert = require('assert');
 const {
   buildIssueFingerprint,
   buildReadableErrorMessage,
+  classifyHttpError,
+  extractResponseMetadata,
   getPathPattern,
   getSentryConfig,
   buildSentryTunnelUrl,
@@ -11,7 +13,8 @@ const {
   sanitizeStack,
   sanitizeUrl,
   shouldPreferFetchTransport,
-  shouldReportRequestError
+  shouldReportRequestError,
+  shouldSuppressRequestError
 } = require('./sentryConfig');
 
 function test(name, fn) {
@@ -188,7 +191,8 @@ test('buildReadableErrorMessage summarizes api failures for issue lists', functi
   );
 });
 
-test('buildIssueFingerprint groups api errors by status method and route', function() {
+test('buildIssueFingerprint groups api errors by error class and business code', function() {
+  // All 502 errors group together regardless of endpoint
   assert.deepStrictEqual(
     buildIssueFingerprint(new Error('Request failed'), {
       errorSource: 'api',
@@ -196,7 +200,41 @@ test('buildIssueFingerprint groups api errors by status method and route', funct
       method: 'get',
       route: '/console/teams/:id/apps/:id/events'
     }, []),
-    ['rainbond-ui-api', '502', 'GET', '/console/teams/:id/apps/:id/events']
+    ['rainbond-ui-api', 'gateway', 'no-code']
+  );
+
+  // 500 errors group together
+  assert.deepStrictEqual(
+    buildIssueFingerprint(new Error('Request failed'), {
+      errorSource: 'api',
+      status: 500,
+      method: 'post',
+      route: '/console/teams/:id/apps/:id/overview'
+    }, []),
+    ['rainbond-ui-api', 'backend', 'no-code']
+  );
+
+  // Network errors group together
+  assert.deepStrictEqual(
+    buildIssueFingerprint(new Error('Request failed'), {
+      errorSource: 'api',
+      status: 'network',
+      method: 'get',
+      route: '/console/teams/:id/apps/:id/configs'
+    }, []),
+    ['rainbond-ui-api', 'network', 'no-code']
+  );
+
+  // Errors with same business code group together
+  assert.deepStrictEqual(
+    buildIssueFingerprint(new Error('Request failed'), {
+      errorSource: 'api',
+      status: 500,
+      method: 'get',
+      route: '/console/teams/:id/apps/:id/overview',
+      businessCode: '10411'
+    }, []),
+    ['rainbond-ui-api', 'backend', '10411']
   );
 });
 
@@ -210,4 +248,81 @@ test('shouldPreferFetchTransport sends api errors through visible fetch requests
   assert.strictEqual(shouldPreferFetchTransport({ tags: { error_source: 'api' } }), true);
   assert.strictEqual(shouldPreferFetchTransport({ errorSource: 'api' }), true);
   assert.strictEqual(shouldPreferFetchTransport({ tags: { error_source: 'window_error' } }), false);
+});
+
+test('classifyHttpError returns correct error class', function() {
+  // Network errors (no response)
+  assert.strictEqual(classifyHttpError(null), 'network');
+  assert.strictEqual(classifyHttpError({}), 'network');
+  assert.strictEqual(classifyHttpError({ response: null }), 'network');
+
+  // Specific 5xx classes
+  assert.strictEqual(classifyHttpError({ response: { status: 502 } }), 'gateway');
+  assert.strictEqual(classifyHttpError({ response: { status: 503 } }), 'overloaded');
+  assert.strictEqual(classifyHttpError({ response: { status: 504 } }), 'timeout');
+  assert.strictEqual(classifyHttpError({ response: { status: 500 } }), 'backend');
+  assert.strictEqual(classifyHttpError({ response: { status: 599 } }), 'other');
+});
+
+test('shouldSuppressRequestError suppresses expected transient errors', function() {
+  // Network errors WITH a custom handler are suppressed
+  assert.strictEqual(
+    shouldSuppressRequestError(new Error('timeout'), { handleError: () => {} }),
+    true
+  );
+
+  // Network errors WITHOUT a custom handler are NOT suppressed
+  assert.strictEqual(
+    shouldSuppressRequestError(new Error('timeout'), {}),
+    false
+  );
+
+  // 502, 503, 504 are suppressed (transient gateway errors)
+  assert.strictEqual(shouldSuppressRequestError({ response: { status: 502 } }), true);
+  assert.strictEqual(shouldSuppressRequestError({ response: { status: 503 } }), true);
+  assert.strictEqual(shouldSuppressRequestError({ response: { status: 504 } }), true);
+
+  // 500 is NOT suppressed (real backend errors should be reported)
+  assert.strictEqual(shouldSuppressRequestError({ response: { status: 500 } }), false);
+
+  // null error is not suppressed
+  assert.strictEqual(shouldSuppressRequestError(null), false);
+});
+
+test('extractResponseMetadata pulls backend request id and error code', function() {
+  assert.deepStrictEqual(
+    extractResponseMetadata(null),
+    {}
+  );
+
+  assert.deepStrictEqual(
+    extractResponseMetadata({
+      headers: { 'x-request-id': 'req-123' },
+      data: { code: 10411, msg_show: 'cluster unavailable' }
+    }),
+    {
+      request_id: 'req-123',
+      backend_error_code: 10411,
+      response_message: 'cluster unavailable'
+    }
+  );
+
+  // Falls back to X-Request-Id (capitalized)
+  assert.deepStrictEqual(
+    extractResponseMetadata({
+      headers: { 'X-Request-Id': 'req-456' },
+      data: { msg: 'error' }
+    }),
+    {
+      request_id: 'req-456',
+      backend_error_code: '',
+      response_message: 'error'
+    }
+  );
+
+  // Empty response still returns defaults
+  assert.deepStrictEqual(
+    extractResponseMetadata({}),
+    { request_id: '', backend_error_code: '', response_message: '' }
+  );
 });


### PR DESCRIPTION
Ref goodrain/rainbond#2620

- Group API errors by error class and business code instead of endpoint
- Add backend_error_class, request_id, business_code Sentry tags
- Suppress expected transient errors (502/503/504)
- Extract x-request-id for backend log correlation

Generated with [Claude Code](https://claude.ai/code)