### PR TITLE
feat: add data-testid anchors for local market install flow

### DIFF
--- a/src/components/AppMarketContent/index.js
+++ b/src/components/AppMarketContent/index.js
@@ -187,6 +187,7 @@ const AppMarketContent = forwardRef(({
                 ]
               })(
                 <Select
+                  data-testid="rbd-market-version-select"
                   getPopupContainer={triggerNode => triggerNode.parentNode}
                   onChange={onChangeVersion}
                   style={{ width: '100%' }}
@@ -261,7 +262,7 @@ const AppMarketContent = forwardRef(({
                   message: '最多24个字符'
                 }
               ]
-            })(<Input placeholder="请输入应用名称" />)}
+            })(<Input data-testid="rbd-market-app-name-input" placeholder="请输入应用名称" />)}
           </Form.Item>
         )}
 
@@ -277,6 +278,7 @@ const AppMarketContent = forwardRef(({
               ]
             })(
               <Select
+                data-testid="rbd-market-group-select"
                 placeholder="请选择应用"
                 style={{ width: '100%' }}
                 getPopupContainer={triggerNode => triggerNode.parentNode}

--- a/src/components/MarketModal/index.js
+++ b/src/components/MarketModal/index.js
@@ -320,7 +320,7 @@ const MarketModal = ({ visible, onCancel, dispatch, currentEnterprise, store, gr
               </div>
               <div className={styles.actionButtons}>
                 <Button onClick={handleBack}>返回</Button>
-                <Button onClick={handleSubmitInstall} type="primary" loading={addAppLoading}>
+                <Button data-testid="rbd-market-install-submit" onClick={handleSubmitInstall} type="primary" loading={addAppLoading}>
                   安装
                 </Button>
               </div>
@@ -328,7 +328,7 @@ const MarketModal = ({ visible, onCancel, dispatch, currentEnterprise, store, gr
           ) : (
             [
               <Button key="back" onClick={handleBack}>返回</Button>,
-              <Button key="install" onClick={handleSubmitInstall} type="primary" loading={addAppLoading}>
+              <Button key="install" data-testid="rbd-market-install-submit" onClick={handleSubmitInstall} type="primary" loading={addAppLoading}>
                 安装
               </Button>
             ]
@@ -337,6 +337,7 @@ const MarketModal = ({ visible, onCancel, dispatch, currentEnterprise, store, gr
       }
       width={currentView === 'install' ? 500 : 800}
       centered
+      data-testid="rbd-market-install-modal"
       className={styles.marketModal}
     >
       <AppMarketContent

--- a/src/pages/Create/market.js
+++ b/src/pages/Create/market.js
@@ -944,6 +944,7 @@ export default class Main extends PureComponent {
     const defaultActions = isInstall
       ? [
         <span
+          data-testid="rbd-market-install-btn"
           onClick={() => {
             if (type === 'helm') {
               this.handleHelmIntall(item);
@@ -962,6 +963,8 @@ export default class Main extends PureComponent {
           <GoodrainRZ style={{ marginLeft: 6, marginTop: 6 }} />
         )}
         <Card
+          data-testid="rbd-market-card"
+          data-name={item.app_name || item.name}
           className={
             handleType
               ? `${type === 'helm' ? PluginStyles.cards_helm_drawer : PluginStyles.cards} ${PluginStyles.clearAvatar}`
@@ -1382,6 +1385,7 @@ export default class Main extends PureComponent {
         {scopeMax != 'command' &&
           <span id="searchWrap" style={{ display: 'inline-block' }}>
             <Input.Search
+              data-testid="rbd-market-search"
               // eslint-disable-next-line react/no-string-refs
               ref="searchs"
               placeholder={formatMessage({ id: 'placeholder.group_name' })}


### PR DESCRIPTION
## What

Adds E2E `data-testid` anchors for the **local application market install** flow, continuing the anchor series from #1797 and #1838.

**Market list** (`pages/Create/market.js`, shared by local/cloud `renderApp`):
- `rbd-market-card` (+ `data-name` carrying the template name) — template card
- `rbd-market-search` — template search box
- `rbd-market-install-btn` — install action

**Local install modal** (`MarketModal` + `AppMarketContent`):
- `rbd-market-install-modal` — modal container
- `rbd-market-version-select` — version selector
- `rbd-market-app-name-input` — new application name input
- `rbd-market-group-select` — target application group selector
- `rbd-market-install-submit` — install submit button (both footer render branches)

## Why

The E2E suite drives a market install journey (publish a template via API, then install it through the UI). Stable `data-testid` anchors replace brittle text/role selectors for the market list and install modal, mirroring the convention established in #1797.

## Notes

- Pure attribute additions — no logic changes (10 insertions across 3 files).
- Scope is the **local** market path only; cloud market modal (`CreateAppFromMarketForm`) anchors are deferred until the cloud journey is tested.
- Naming follows the `rbd-<area>-<element>` convention.