### PR TITLE
feat: add data-testid anchors for component runtime ops

### DIFF
--- a/src/components/AddOrEditVolume/index.js
+++ b/src/components/AddOrEditVolume/index.js
@@ -248,6 +248,7 @@ export default class AddVolumes extends PureComponent {
               ]
             })(
               <Input
+                data-testid="rbd-volume-name-input"
                 placeholder={formatMessage({ id: 'componentOverview.body.AddVolumes.required' })}
                 disabled={!!this.props.editor}
               />
@@ -284,7 +285,7 @@ export default class AddVolumes extends PureComponent {
                     validator: this.checkMountPath
                   }
                 ]
-              })(<Input placeholder={formatMessage({ id: 'componentOverview.body.AddVolumes.volume_path_placeholder' })} />)}
+              })(<Input data-testid="rbd-volume-path-input" placeholder={formatMessage({ id: 'componentOverview.body.AddVolumes.volume_path_placeholder' })} />)}
             </FormItem>
           )}
           {method != 'vm' &&
@@ -359,7 +360,7 @@ export default class AddVolumes extends PureComponent {
           >
             <FormattedMessage id='componentOverview.body.AddVolumes.cancel' />
           </Button>
-          <Button onClick={this.handleSubmit} type="primary">
+          <Button data-testid="rbd-volume-submit-btn" onClick={this.handleSubmit} type="primary">
             <FormattedMessage id='componentOverview.body.AddVolumes.confirm' />
           </Button>
         </div>

--- a/src/components/EnvironmentVariable/index.js
+++ b/src/components/EnvironmentVariable/index.js
@@ -125,6 +125,13 @@ class EditableCell extends React.Component {
             })(
               <Input
                 // disabled={!addVariable && dataIndex === 'attr_name'}
+                data-testid={
+                  dataIndex === 'attr_name'
+                    ? 'rbd-env-key-input'
+                    : dataIndex === 'attr_value'
+                    ? 'rbd-env-value-input'
+                    : undefined
+                }
                 placeholder={placeholders}
               />
             )}
@@ -887,6 +894,7 @@ class EnvironmentVariable extends React.Component {
                 <EditableContext.Consumer>
                   {form => (
                     <Button
+                      data-testid="rbd-env-save-btn"
                       loading={editEvnsLoading || addInnerEnvsLoading}
                       onClick={() => this.save(form, data.ID)}
                       type="link"
@@ -1001,7 +1009,7 @@ class EnvironmentVariable extends React.Component {
     );
 
     const addButton = (
-      <Button onClick={this.handleAdd} disabled={addVariable}>
+      <Button data-testid="rbd-env-add-btn" onClick={this.handleAdd} disabled={addVariable}>
         <Icon type="plus" />
         {/* 添加变量 */}
         <FormattedMessage id='componentOverview.body.tab.env.table.column.add'/>

--- a/src/pages/Component/expansion.js
+++ b/src/pages/Component/expansion.js
@@ -1496,7 +1496,7 @@ export default class Index extends PureComponent {
               }
               {this.state.editBillInfo ?
                 <div style={{ marginLeft: 10 }}>
-                  <Button type='primary' icon='save' style={{ marginRight: 10 }} onClick={this.handleFromData} disabled={isVmGpuScalingLocked}>
+                  <Button data-testid="rbd-scale-submit" type='primary' icon='save' style={{ marginRight: 10 }} onClick={this.handleFromData} disabled={isVmGpuScalingLocked}>
                     {method === 'vm'
                       ? formatMessage({
                         id: vmWillRestartForScaling
@@ -1523,7 +1523,7 @@ export default class Index extends PureComponent {
                   </Button>
                 </div>
                 :
-                <Button icon='edit' onClick={() => this.setState({ editBillInfo: true })} disabled={isVmGpuScalingLocked}>
+                <Button data-testid="rbd-scale-edit-btn" icon='edit' onClick={() => this.setState({ editBillInfo: true })} disabled={isVmGpuScalingLocked}>
                   {method === 'vm'
                     ? formatMessage({ id: 'componentOverview.body.tab.overview.vmHotUpdateEdit' })
                     : formatMessage({ id: 'componentOverview.body.tab.env.table.column.edit' })}
@@ -1630,21 +1630,23 @@ export default class Index extends PureComponent {
                 label={<FormattedMessage id='componentOverview.body.Expansion.number' />}
                 {...formItemLayout}
               >
-                {getFieldDecorator('node', {
-                  initialValue: extendInfo.current_node
-                })(
-                  <Select
-                    disabled={!this.state.editBillInfo || horizontalScalingDisabled}
-                    style={{ width: 500 }}
-                    getPopupContainer={triggerNode => triggerNode.parentNode}
-                  >
-                    {(extendInfo.node_list || []).map(item => (
-                      <Option key={item} value={item}>
-                        {item}
-                      </Option>
-                    ))}
-                  </Select>
-                )}
+                <span data-testid="rbd-scale-instance-input">
+                  {getFieldDecorator('node', {
+                    initialValue: extendInfo.current_node
+                  })(
+                    <Select
+                      disabled={!this.state.editBillInfo || horizontalScalingDisabled}
+                      style={{ width: 500 }}
+                      getPopupContainer={triggerNode => triggerNode.parentNode}
+                    >
+                      {(extendInfo.node_list || []).map(item => (
+                        <Option key={item} value={item}>
+                          {item}
+                        </Option>
+                      ))}
+                    </Select>
+                  )}
+                </span>
               </Form.Item>
             )}
           </Form>

--- a/src/pages/Component/mnt.js
+++ b/src/pages/Component/mnt.js
@@ -828,7 +828,7 @@ export default class Index extends PureComponent {
             style={{ marginBottom: 24 }}
             title={<span>{formatMessage({ id: 'componentOverview.body.mnt.save_setting' })}</span>}
             extra={
-              <Button onClick={this.handleAddVar}>
+              <Button data-testid="rbd-volume-add-btn" onClick={this.handleAddVar}>
                 <Icon type="plus" />
                 {formatMessage({ id: 'componentOverview.body.mnt.add_storage' })}
               </Button>
@@ -858,7 +858,7 @@ export default class Index extends PureComponent {
                 >
                   {formatMessage({ id: 'button.save' })}
                 </Button>
-                <Button onClick={this.handleAddVar}>
+                <Button data-testid="rbd-volume-add-btn" onClick={this.handleAddVar}>
                   <Icon type="plus" />
                   {formatMessage({ id: 'componentOverview.body.mnt.add_storage' })}
                 </Button>


### PR DESCRIPTION
## What

Add `data-testid` anchors to component **runtime-ops** controls so the E2E
suite can drive these UI flows and verify wiring against the backend API.

| Area | Anchors |
|------|---------|
| Env variables (`EnvironmentVariable`) | `rbd-env-add-btn`, `rbd-env-key-input`, `rbd-env-value-input`, `rbd-env-save-btn` |
| Storage (`mnt` / `AddOrEditVolume`) | `rbd-volume-add-btn`, `rbd-volume-name-input`, `rbd-volume-path-input`, `rbd-volume-submit-btn` |
| Scaling (`expansion`) | `rbd-scale-edit-btn`, `rbd-scale-instance-input`, `rbd-scale-submit` |

## Notes

- Anchors are attached to the **actually-rendered** control elements (Inputs/Buttons forward `data-testid` to the DOM natively).
- The scaling instance `<Select>` lives inside `getFieldDecorator`; its testid is carried on a wrapping `<span>` so the anchor reaches the DOM **without** disturbing the form-field binding.
- The env key/value inline cell reuses one `<Input>`; the testid is chosen by `dataIndex` (`attr_name`/`attr_value`).
- Pure additive change — no behavior change, follows the `rbd-*` naming from #1797/#1838/#1839/#1841.

Co-developed for the rainbond E2E UI coverage effort.