### PR TITLE
feat: add data-testid anchors for dependency, port and health-check ops

### DIFF
--- a/src/components/AddPort/index.js
+++ b/src/components/AddPort/index.js
@@ -64,6 +64,7 @@ export default class AddPort extends PureComponent {
       <Modal
         title={<FormattedMessage id='componentOverview.body.AddPort.title'/>}
         onOk={this.handleSubmit}
+        okButtonProps={{ 'data-testid': 'rbd-port-add-submit' }}
         onCancel={this.props.onCancel}
         visible={true}
       >
@@ -76,6 +77,7 @@ export default class AddPort extends PureComponent {
               ]
             })(
               <Input
+                data-testid="rbd-port-input"
                 type="number"
                 placeholder={
                   this.props.isImageApp || this.props.isDockerfile

--- a/src/components/AddRelation/index.js
+++ b/src/components/AddRelation/index.js
@@ -140,6 +140,7 @@ export default class AddRelation extends PureComponent {
         width={1000}
         visible
         onOk={this.handleSubmit}
+        okButtonProps={{ 'data-testid': 'rbd-dep-submit' }}
         onCancel={this.handleCancel}
       >
         <Row>

--- a/src/pages/Component/port.js
+++ b/src/pages/Component/port.js
@@ -637,7 +637,7 @@ export default class Index extends PureComponent {
           </Col>
           {!isHelm && (
             <Col span={9} style={{ textAlign: 'right' }}>
-              <Button onClick={this.showAddPort}>
+              <Button data-testid="rbd-port-add-btn" onClick={this.showAddPort}>
                 <Icon type="plus" />
                 <FormattedMessage id="componentOverview.body.Port.add" />
               </Button>

--- a/src/pages/Component/relation.js
+++ b/src/pages/Component/relation.js
@@ -181,7 +181,7 @@ export default class Index extends PureComponent {
               <span className={styles.desc}>{formatMessage({ id: 'componentOther.relationMnt.desc_relation' })}</span>
             </>}
             extra={
-              <Button onClick={this.showAddRelation}>
+              <Button data-testid="rbd-dep-add-btn" onClick={this.showAddRelation}>
                 <Icon type="plus" /> <FormattedMessage id='componentOverview.body.Relation.EnvironmentVariable.add' />
               </Button>
             }

--- a/src/pages/Component/setting.js
+++ b/src/pages/Component/setting.js
@@ -893,6 +893,7 @@ export default class Index extends React.Component {
                 {startProbe && (
                   <div>
                     <Button
+                      data-testid="rbd-probe-set-btn"
                       onClick={() => {
                         this.setState({ editStartHealth: startProbe });
                       }}

--- a/src/pages/Component/setting/edit-health-check.js
+++ b/src/pages/Component/setting/edit-health-check.js
@@ -189,6 +189,7 @@ export default class EditHealthCheck extends PureComponent {
         width={700}
         title={title}
         onOk={this.handleSubmit}
+        okButtonProps={{ 'data-testid': 'rbd-probe-submit' }}
         maskClosable={false}
         onCancel={onCancel}
         visible


### PR DESCRIPTION
## What

Extends the component runtime-ops E2E anchors (after #1842 env/storage/scale) to **dependency / port / health-check**, so those component-detail flows can be driven by Playwright and verified against the backend API.

| Area | Anchors | Files |
|------|---------|-------|
| Dependency (依赖) | `rbd-dep-add-btn`, `rbd-dep-submit` | `pages/Component/relation.js`, `components/AddRelation` |
| Port (端口) | `rbd-port-add-btn`, `rbd-port-input`, `rbd-port-add-submit` | `pages/Component/port.js`, `components/AddPort` |
| Health-check (健康检查) | `rbd-probe-set-btn`, `rbd-probe-submit` | `pages/Component/setting.js`, `pages/Component/setting/edit-health-check.js` |

## Notes

- Modal confirm buttons (AddRelation / AddPort / EditHealthCheck use antd's **default footer**) carry the testid via `okButtonProps={{ 'data-testid': ... }}` so it reaches the rendered OK button.
- Inputs/Buttons forward `data-testid` to the DOM natively.
- Pure additive, no behavior change; follows the `rbd-*` scheme from #1797/#1838/#1839/#1841/#1842.