### PR TITLE
feat: add data-testid anchors for app list and component monitor panel

### DIFF
--- a/src/pages/Component/monitor.js
+++ b/src/pages/Component/monitor.js
@@ -101,7 +101,7 @@ export default class Index extends PureComponent {
             </Menu>
           </Row>
         )}
-        <Row>
+        <Row data-testid="rbd-comp-monitor-panel">
           {currentMenu === 'trace' ? <TraceShow /> : <ResourceShow />}
         </Row>
       </>

--- a/src/pages/TeamDashboard/TeamBasicInfo/index.js
+++ b/src/pages/TeamDashboard/TeamBasicInfo/index.js
@@ -417,6 +417,8 @@ export default class index extends Component {
               return (
                 <div key={item.group_id}>
                   <div
+                    data-testid="rbd-app-card"
+                    data-name={item.group_name}
                     className={styles.teamHotAppItem}
                     onClick={() => {
                       dispatch(routerRedux.push(
@@ -627,6 +629,7 @@ export default class index extends Component {
               <div className={styles.appListHeaderTop}>
                 <div className={styles.appListToolbar}>
                   <Search
+                    data-testid="rbd-app-search"
                     placeholder={formatMessage({ id: 'teamOverview.searchTips' })}
                     onSearch={this.onSearch}
                     value={query}


### PR DESCRIPTION
## What

Two small E2E anchor additions:

| Area | Anchors | File |
|------|---------|------|
| App list | `rbd-app-search`, `rbd-app-card` (+ `data-name={group_name}`) | `pages/TeamDashboard/TeamBasicInfo/index.js` |
| Component monitor | `rbd-comp-monitor-panel` | `pages/Component/monitor.js` |

- De-flakes `key-page-render` (app cards currently matched by text/structure).
- Enables a monitor-tab render smoke (panel-not-blank).
- Pure additive, no behavior change; `rbd-*` scheme per #1797/#1838/#1839/#1841/#1842/#1844.