### PR TITLE
feat: add data-testid anchors for gateway HTTP route drawer

### DIFF
--- a/src/components/GatewayRouteHttp/index.js
+++ b/src/components/GatewayRouteHttp/index.js
@@ -418,6 +418,7 @@ export default class index extends Component {
                     />
                     {isCreate && (
                         <Button
+                            data-testid="rbd-gw-route-add-btn"
                             icon="plus"
                             type="primary"
                             onClick={() => this.routeDrawerShow({}, 'add')}

--- a/src/components/RouteDrawerHttp/index.js
+++ b/src/components/RouteDrawerHttp/index.js
@@ -712,14 +712,14 @@ export default class index extends Component {
                 >
                     <Form hideRequiredMark onSubmit={this.handleSubmit}>
                         <Form.Item {...formItemLayout} label={formatMessage({ id: 'teamNewGateway.NewGateway.GatewayRoute.host' })}>
-                            {getFieldDecorator('hosts', {
+                            <span data-testid="rbd-gw-route-host">{getFieldDecorator('hosts', {
                                 rules: [
                                     { validator: this.handleValidatorsHosts },
                                     // 域名不允许填入ip
                                     { validator: this.handleValidatorsHostsIp },
                                 ],
                                 initialValue: (editInfo && editInfo.match && editInfo.match.hosts) || []
-                            })(<DAHosts hostPlaceholder={formatMessage({ id: 'teamNewGateway.NewGateway.RouteDrawer.InputHost' })} isEdit={Object.keys(editInfo).length > 0} isHosts={true} />)}
+                            })(<DAHosts hostPlaceholder={formatMessage({ id: 'teamNewGateway.NewGateway.RouteDrawer.InputHost' })} isEdit={Object.keys(editInfo).length > 0} isHosts={true} />)}</span>
                             <span style={{ fontWeight: 'bold', fontSize: '16px' }}>
                                 <a href="javascript:void(0)" onClick={this.showDescription}>
                                     {formatMessage({ id: 'popover.access_strategy.lable.analysis' })}
@@ -890,12 +890,12 @@ export default class index extends Component {
                                                     </>
                                                 }
                                                 >
-                                                    {getFieldDecorator('comListInfo', {
+                                                    <span data-testid="rbd-gw-route-backend">{getFieldDecorator('comListInfo', {
                                                         rules: [{ validator: this.handleValidators }],
                                                         initialValue: (editInfo && editInfo.backends && this.handleService(editInfo.backends, "backends")) || []
                                                     })(
                                                         <ServiceInputK8s comList={serviceComponentList} />
-                                                    )}
+                                                    )}</span>
                                                 </Form.Item>
                                             </Skeleton>
                                         }
@@ -978,7 +978,7 @@ export default class index extends Component {
                         <Button onClick={this.onClose} style={{ marginRight: 8 }}>
                             {formatMessage({ id: 'popover.cancel' })}
                         </Button>
-                        <Button type="primary" loading={editHttpStrategyLoading} onClick={this.handleSubmit}>
+                        <Button data-testid="rbd-gw-route-submit" type="primary" loading={editHttpStrategyLoading} onClick={this.handleSubmit}>
                             {formatMessage({ id: 'popover.confirm' })}
                         </Button>
                     </div>


### PR DESCRIPTION
Add `data-testid` anchors so E2E tests can drive the gateway **HTTP route** creation flow (the new API-gateway route subsystem that replaced the legacy per-port bind-domain UI) through pure `getByTestId`.

- `rbd-gw-route-add-btn` — the "add route" button (`components/GatewayRouteHttp/index.js`).
- `rbd-gw-route-submit` — the drawer submit button (`components/RouteDrawerHttp/index.js`, custom footer).
- `rbd-gw-route-host` / `rbd-gw-route-backend` — `<span>` wrappers around the `getFieldDecorator(...)` **return values** for the host input (DAHosts) and the target-component selector (ServiceInputK8s). Wrapping the decorator's return (not the control passed into it) keeps the antd form binding intact while giving tests a stable scope; the shared DAHosts/ServiceInputK8s components are left untouched.

No behavior change — anchors only.