### PR TITLE
fix: restore rbd-comp-monitor-panel testid on monitor panel Row

### DIFF
--- a/src/pages/Component/monitor.js
+++ b/src/pages/Component/monitor.js
@@ -44,7 +44,7 @@ export default class Index extends PureComponent {
     if (!this.canView()) return <NoPermTip />;
 
     return (
-      <Row>
+      <Row data-testid="rbd-comp-monitor-panel">
         <ResourceShow />
       </Row>
     );


### PR DESCRIPTION
## What

Re-adds `data-testid="rbd-comp-monitor-panel"` to the component monitor panel `<Row>` in `src/pages/Component/monitor.js`.

## Why

This anchor was added and merged in #1845 (`feat: add data-testid anchors for app list and component monitor panel`), but was **lost on `main`** when `monitor.js` was later refactored (the `TraceShow`/`ResourceShow` conditional Row was simplified to a single `ResourceShow` Row, dropping the attribute). The app-list half of #1845 (`TeamBasicInfo`) survived; only the monitor half was clobbered.

As a result `main` no longer matches the e2e suite: `tests/ui/component-monitor-render.spec.ts` asserts `getByTestId('rbd-comp-monitor-panel')` is visible. It still passes on the current CI baseline image (built right after #1845, before the refactor), so nightly/PR gates stayed green and masked the drift — but a full prerelease run of 3-repo `main` caught it (the panel renders fine; only the testid was missing).

## Change

1-line, equivalent to #1845's original anchor, placed on today's `ResourceShow` Row:

```diff
-      <Row>
+      <Row data-testid="rbd-comp-monitor-panel">
         <ResourceShow />
       </Row>
```

After merge, rebuilding the e2e CI baseline from `main` will keep `component-monitor-render` green.