### PR TITLE
fix: guard SlidePanel redirect for unchecked components

### DIFF
--- a/src/components/SlidePanel/components/components.js
+++ b/src/components/SlidePanel/components/components.js
@@ -725,15 +725,17 @@ class Main extends PureComponent {
               })
             }, 100)
           } else {
-            const fallbackRoute = buildAppOverviewFallbackRoute({
-              prefixUrl,
-              groupId: group_id || globalUtil.getAppID()
-            });
             this.setState({
               routerSwitch: false
             })
-            fallbackRoute &&
-              dispatch(routerRedux.replace(fallbackRoute));
+            if (group_id) {
+              const fallbackRoute = buildAppOverviewFallbackRoute({
+                prefixUrl,
+                groupId: group_id
+              });
+              fallbackRoute &&
+                dispatch(routerRedux.replace(fallbackRoute));
+            }
           }
         } else {
           this.getStatus(false);


### PR DESCRIPTION
## Summary

- PR #1856 introduced `globalUtil.getAppID()` as fallback in `buildAppOverviewFallbackRoute`, which always resolves from the URL. This caused the redirect to fire on first `loadDetail` callback — before the DVA reducer updates props — redirecting unchecked components away from their tab page to the overview.
- Removed the `globalUtil.getAppID()` fallback so the redirect only fires when `group_id` is available from props (after the reducer update), restoring the pre-#1856 behavior.

## Root cause

In the `fetchDetail` callback, `this.fetchParameter()` reads from `this.props` which haven't been updated yet (the DVA `yield put` queues the store update, but React re-renders asynchronously). So `group_id` from props is `undefined` on first load. The old code's `serviceAlias && dispatch(...)` was similarly guarded (serviceAlias was also undefined), preventing the redirect. The new code's `globalUtil.getAppID()` fallback bypassed this implicit guard.

## Impact

4 E2E tests that navigate to component tabs (dependency, port, probe, monitor) for unchecked components fail with 20s timeout — the redirect closes the tab panel before testid elements appear. Real users hitting a component tab URL for an unchecked component would also be unexpectedly redirected to the overview page.

## Test plan

- [ ] Prerelease E2E: `component-dep-wiring`, `component-ops-wiring`, `component-probe-wiring`, `component-monitor-render` should pass
- [ ] Manual: create image component → navigate to port tab without running check → "添加端口" button should be visible (not redirected to overview)