### PR TITLE
fix: avoid duplicate gateway certificate requests

### DIFF
--- a/src/models/gateWay.js
+++ b/src/models/gateWay.js
@@ -40,8 +40,6 @@ import {
     handleApiGatewayService,
     deleteApiGatewayService,
     fetchGetServiceAddress,
-    handleApiGatewayCert,
-    deleteApiGatewayCert,
     fetchGetTcpService,
     fetchEditTcpService,
     fetchDeleteTcpService,
@@ -357,18 +355,6 @@ export default {
         },
         *fetchGetServiceAddress({ callback, payload, handleError }, { call }) {
             const response = yield call(fetchGetServiceAddress, payload, handleError);
-            if (callback) {
-                callback(response)
-            }
-        },
-        *handleApiGatewayCert({ callback, payload, handleError }, { call }) {
-            const response = yield call(handleApiGatewayCert, payload, handleError);
-            if (callback) {
-                callback(response)
-            }
-        },
-        *deleteApiGatewayCert({ callback, payload, handleError }, { call }) {
-            const response = yield call(deleteApiGatewayCert, payload, handleError);
             if (callback) {
                 callback(response)
             }

--- a/src/pages/NewGateway/GatewayCertificate/ManualIssuance.js
+++ b/src/pages/NewGateway/GatewayCertificate/ManualIssuance.js
@@ -134,39 +134,6 @@ class Control extends Component {
   handleClose = () => {
     this.setState({ visibleDrawer: false, editData: '' });
   };
-  handleApiGatewayCert = (values, type) => {
-    this.props.dispatch({
-      type: 'gateWay/handleApiGatewayCert',
-      payload: {
-        alias: values.alias,
-        teamName: globalUtil.getCurrTeamName()
-      },
-      callback: data => {
-        if (data && data.status_code === 200) {
-          if (type == 'add') {
-            notification.success({ message: formatMessage({ id: 'notification.success.add' }) });
-            this.setState({ visibleDrawer: false }, () => {
-              this.load();
-            });
-          } else {
-            notification.success({ message: data ? formatMessage({ id: 'notification.success.change' }) : formatMessage({ id: 'notification.error.change' }) });
-            this.setState({ visibleDrawer: false }, () => {
-              this.load();
-            });
-          }
-        }
-      }
-    });
-  }
-  deleteApiGatewayCert = (values) => {
-    this.props.dispatch({
-      type: 'gateWay/deleteApiGatewayCert',
-      payload: {
-        alias: values.alias,
-        teamName: globalUtil.getCurrTeamName()
-      }
-    });
-  }
   /** 添加证书 */
   handleOk = values => {
     const { editData } = this.state;
@@ -186,9 +153,10 @@ class Control extends Component {
         },
         callback: data => {
           if (data && data.status_code === 200) {
-            setTimeout(() => {
-              this.handleApiGatewayCert(values, 'add')
-            }, 500);
+            notification.success({ message: formatMessage({ id: 'notification.success.add' }) });
+            this.setState({ visibleDrawer: false }, () => {
+              this.load();
+            });
           }
         }
       });
@@ -205,9 +173,10 @@ class Control extends Component {
         },
         callback: data => {
           if (data && data.status_code === 200) {
-            setTimeout(() => {
-              this.handleApiGatewayCert(values, 'edit')
-            }, 500);
+            notification.success({ message: formatMessage({ id: 'notification.success.change' }) });
+            this.setState({ visibleDrawer: false }, () => {
+              this.load();
+            });
           }
         }
       });
@@ -215,7 +184,6 @@ class Control extends Component {
   };
   /** 删除证书 */
   handleDelete = record => {
-    this.deleteApiGatewayCert(record)
     this.props.dispatch({
       type: 'gateWay/deleteLicense',
       payload: {

--- a/src/services/gateWay.js
+++ b/src/services/gateWay.js
@@ -604,19 +604,6 @@ export async function deleteApiGatewayService(params, handleError) {
   );
 }
 
-/** 新增或编辑Api-Gateway证书 */
-export async function handleApiGatewayCert(params, handleError) {
-  return request(
-    `${apiconfig.baseUrl}/console/api-gateway/v1/${params.teamName}/cert/${params.alias}`,
-    {
-      method: 'post',
-      handleError
-    }
-  );
-}
-
-
-
 // 获取团队网关数据
 export async function getTeamGatewayData(params, handleError) {
   return request(
@@ -633,16 +620,6 @@ export async function getTeamGatewayData(params, handleError) {
     }
   )
 }
-export async function deleteApiGatewayCert(params, handleError) {
-  return request(
-    `${apiconfig.baseUrl}/console/api-gateway/v1/${params.teamName}/cert/${params.alias}`,
-    {
-      method: 'delete',
-      handleError
-    }
-  );
-}
-
 // 获取服务地址列表
 export function fetchGetServiceAddress(params) {
   return request(


### PR DESCRIPTION
## Summary

- Use the console certificate endpoints as the single write path for add, update, and delete.
- Remove duplicate direct APISIX certificate requests and their unused DVA effects/services.
- Refresh the certificate list immediately after a successful console response.

## Testing

- yarn build
- verified removed API helpers have no remaining references

## Related PRs

- https://github.com/goodrain/rainbond/pull/2666
- https://github.com/goodrain/rainbond-console/pull/2084
- https://github.com/goodrain/rainbond-ui/pull/1892