### PR TITLE
perf: reduce application topology realtime overhead

### DIFF
--- a/src/components/SlidePanel/components/app.js
+++ b/src/components/SlidePanel/components/app.js
@@ -12,7 +12,6 @@ import { buildApp } from '../../../services/createApp';
 import VisterBtnWithIcon from './VisterBtnWithIcon';
 import AppDeteleResource from '../../../components/AppDeteleResource'
 import RapidCopy from '../../../components/RapidCopy';
-import cookie from '../../../utils/cookie';
 import { FormattedMessage } from 'umi';
 import { formatMessage } from '@/utils/intl';
 import pageheaderSvg from '@/utils/pageHeaderSvg';
@@ -28,7 +27,7 @@ import { shouldLoadStorageUsage } from './componentViewPerformance';
   editGroupLoading: loading.effects['application/editGroup'],
   deleteLoading: loading.effects['application/deleteGroupAllResource'],
   currUser: user.currentUser,
-  apps: application.apps,
+  storeApps: application.apps,
   groupDetail: application.groupDetail || {},
   currentTeam: teamControl.currentTeam,
   currentRegionName: teamControl.currentRegionName,
@@ -74,16 +73,19 @@ export default class app extends Component {
       
     };
     this.storageUsageRequested = false;
+    this.statusRequestInFlight = false;
+    this.operatorRequestInFlight = false;
+    this.componentMounted = false;
   }
   componentDidMount() {
     if (!globalUtil.getAppID()) {
       return;
     }
+    this.componentMounted = true;
     this.loading();
-    this.handleArchCpuInfo();
     this.handleWaitLevel();
-    this.handleGroupAllResource()
     this.loadStorageUsageIfNeeded(this.props.pluginsList);
+    document.addEventListener('visibilitychange', this.handleVisibilityChange);
   }
   componentDidUpdate(prevProps) {
     if (prevProps.permissions !== this.props.permissions) {
@@ -94,34 +96,21 @@ export default class app extends Component {
     if (prevProps.pluginsList !== this.props.pluginsList) {
       this.loadStorageUsageIfNeeded(this.props.pluginsList);
     }
+    if (prevProps.apps !== this.props.apps || prevProps.storeApps !== this.props.storeApps) {
+      this.syncComponentSummary(this.getComponents());
+    }
   }
   loading = () => {
     this.fetchAppDetail();
-    this.loadTopology(true);
-    this.fetchAppDetailState();
-    this.getOperator();
+    this.syncComponentSummary(this.getComponents());
+    this.fetchAppDetailState(true);
+    this.getOperator(true);
   };
   componentWillUnmount() {
+    this.componentMounted = false;
     this.closeTimer();
+    document.removeEventListener('visibilitychange', this.handleVisibilityChange);
   };
-  // 获取集群架构信息
-  handleArchCpuInfo = () => {
-    const { dispatch } = this.props;
-    dispatch({
-      type: 'index/fetchArchOverview',
-      payload: {
-        region_name: globalUtil.getCurrRegionName(),
-        team_name: globalUtil.getCurrTeamName()
-      },
-      callback: res => {
-        if (res && res.bean) {
-          this.setState({
-            archInfo: res.list
-          })
-        }
-      }
-    });
-  }
   handleWaitLevel = () => {
     const { dispatch } = this.props;
     dispatch({
@@ -185,7 +174,11 @@ export default class app extends Component {
       }
     });
   };
-  fetchAppDetailState = () => {
+  fetchAppDetailState = (isCycle = false) => {
+    if (this.statusRequestInFlight) {
+      return;
+    }
+    this.statusRequestInFlight = true;
     const { dispatch } = this.props;
     dispatch({
       type: 'application/fetchAppDetailState',
@@ -194,14 +187,66 @@ export default class app extends Component {
         group_id: globalUtil.getAppID()
       },
       callback: res => {
+        this.statusRequestInFlight = false;
+        if (!this.componentMounted) {
+          return;
+        }
         this.setState({
           resources: res.list,
           appStatusConfig: true
         });
+        if (isCycle) {
+          this.scheduleStatusRefresh();
+        }
+      },
+      handleError: err => {
+        this.statusRequestInFlight = false;
+        if (!this.componentMounted) {
+          return;
+        }
+        this.handleError(err);
+        if (isCycle) {
+          this.scheduleStatusRefresh(20000);
+        }
       }
     });
   };
-  getOperator = () => {
+  scheduleStatusRefresh = (delay = 15000) => {
+    if (this.statusTimer) {
+      clearTimeout(this.statusTimer);
+    }
+    if (!this.componentMounted || !this.state.componentTimer) {
+      return;
+    }
+    this.statusTimer = setTimeout(() => {
+      if (document.hidden) {
+        this.scheduleStatusRefresh(delay);
+        return;
+      }
+      this.fetchAppDetailState(true);
+    }, delay);
+  };
+  handleVisibilityChange = () => {
+    if (!this.componentMounted || !this.state.componentTimer) {
+      return;
+    }
+    if (document.hidden) {
+      if (this.statusTimer) {
+        clearTimeout(this.statusTimer);
+      }
+      if (this.operatorTimer) {
+        clearTimeout(this.operatorTimer);
+      }
+      return;
+    }
+    this.fetchAppDetailState(true);
+    this.getOperator(true);
+  };
+  getOperator = (isCycle = false) => {
+    if (this.operatorRequestInFlight) {
+      return;
+    }
+    this.operatorRequestInFlight = true;
     const { dispatch } = this.props;
     dispatch({
       type: 'application/getOperator',
@@ -210,6 +255,10 @@ export default class app extends Component {
         group_id: globalUtil.getAppID(),
       },
       callback: data => {
+        this.operatorRequestInFlight = false;
+        if (!this.componentMounted) {
+          return;
+        }
         if (data && data.status_code == 200) {
           const arr = data.list.service
           if (arr && arr.length > 0) {
@@ -267,8 +316,36 @@ export default class app extends Component {
             })
           }
         }
+        if (isCycle) {
+          this.scheduleOperatorRefresh();
+        }
+      },
+      handleError: err => {
+        this.operatorRequestInFlight = false;
+        if (!this.componentMounted) {
+          return;
+        }
+        this.handleError(err);
+        if (isCycle) {
+          this.scheduleOperatorRefresh();
+        }
       }
     });
+  };
+  scheduleOperatorRefresh = (delay = 60000) => {
+    if (this.operatorTimer) {
+      clearTimeout(this.operatorTimer);
+    }
+    if (!this.componentMounted || !this.state.componentTimer) {
+      return;
+    }
+    this.operatorTimer = setTimeout(() => {
+      if (document.hidden) {
+        this.scheduleOperatorRefresh(delay);
+        return;
+      }
+      this.getOperator(true);
+    }, delay);
   };
   // 获取存储实际占用
   loadStorageUsageIfNeeded = pluginsList => {
@@ -296,54 +373,28 @@ export default class app extends Component {
       }
     });
   }
-  loadTopology(isCycle) {
-    const { dispatch } = this.props;
-    const teamName = globalUtil.getCurrTeamName();
-    const regionName = globalUtil.getCurrRegionName();
-    cookie.set('team_name', teamName);
-    cookie.set('region_name', regionName);
+  getComponents = () => this.props.apps || this.props.storeApps || [];
+  syncComponentSummary = (apps = []) => {
+    const components = apps || [];
+    const serviceIds = components
+      .map(component => component && component.service_id)
+      .filter(Boolean);
+    const service_alias = components
+      .map(component => component && component.service_alias)
+      .filter(Boolean);
 
-    dispatch({
-      type: 'global/fetAllTopology',
-      payload: {
-        region_name: regionName,
-        team_name: teamName,
-        groupId: globalUtil.getAppID()
-      },
-      callback: res => {
-        if (res && res.status_code === 200) {
-          const data = res.bean;
-          if (JSON.stringify(data) === '{}') {
-            return;
-          }
-          const serviceIds = [];
-          const service_alias = [];
-          const { json_data } = data;
-          Object.keys(json_data).map(key => {
-            serviceIds.push(key);
-            if (
-              json_data[key].cur_status == 'running' &&
-              json_data[key].is_internet == true
-            ) {
-              service_alias.push(json_data[key].service_alias);
-            }
-          });
-
-          this.setState(
-            {
-              jsonDataLength: Object.keys(json_data).length,
-              service_alias,
-              serviceIds
-            },
-            () => {
-              this.loadLinks(service_alias.join('-'), isCycle);
-            }
-          );
-        }
-      }
+    this.setState({
+      jsonDataLength: components.length,
+      service_alias,
+      serviceIds
     });
-  }
-  loadLinks(serviceAlias, isCycle) {
+    if (service_alias.length > 0) {
+      this.loadLinks(service_alias.join('-'));
+    } else {
+      this.setState({ linkList: [] });
+    }
+  };
+  loadLinks(serviceAlias) {
     const { dispatch } = this.props;
     dispatch({
       type: 'global/queryLinks',
@@ -353,42 +404,13 @@ export default class app extends Component {
       },
       callback: res => {
         if (res && res.status_code === 200) {
-          this.setState(
-            {
-              linkList: res.list || []
-            },
-            () => {
-              if (isCycle) {
-                this.handleTimers(
-                  'timer',
-                  () => {
-                    this.fetchAppDetailState();
-                    this.fetchAppDetail();
-                    this.loadTopology(true);
-                    this.getOperator();
-                  },
-                  10000
-                );
-                setTimeout(() => {
-                  this.checkPermissions();
-                }, 100)
-              }
-            }
-          );
+          this.setState({
+            linkList: res.list || []
+          });
         }
       },
       handleError: err => {
         this.handleError(err);
-        this.handleTimers(
-          'timer',
-          () => {
-            this.fetchAppDetailState();
-            this.fetchAppDetail();
-            this.loadTopology(true);
-            this.getOperator();
-          },
-          20000
-        );
       }
     });
   }
@@ -404,21 +426,15 @@ export default class app extends Component {
       });
     }
   };
-  handleTimers = (timerName, callback, times) => {
-    const { componentTimer } = this.state;
-    if (!componentTimer) {
-      return null;
-    }
-    this[timerName] = setTimeout(() => {
-      if (!globalUtil.getAppID()) {
-        return;
-      }
-      callback();
-    }, times);
-  };
   closeTimer = () => {
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer);
+    }
+    if (this.statusTimer) {
+      clearTimeout(this.statusTimer);
+    }
+    if (this.operatorTimer) {
+      clearTimeout(this.operatorTimer);
     }
   };
   // 根据权限判断是否显示
@@ -779,7 +795,7 @@ export default class app extends Component {
           });
           this.handlePromptModalClose();
         }
-        this.loadTopology(false);
+        this.fetchAppDetailState(true);
       });
     } else {
       dispatch({
@@ -797,7 +813,7 @@ export default class app extends Component {
             });
             this.handlePromptModalClose();
           }
-          this.loadTopology(false);
+          this.fetchAppDetailState(true);
         }
       });
     }
@@ -815,7 +831,7 @@ export default class app extends Component {
   };
   toDelete = () => {
     this.closeComponentTimer();
-    this.setState({ toDelete: true });
+    this.setState({ toDelete: true }, this.handleGroupAllResource);
   };
   toDeleteResource = () => {
     this.setState({ toDeleteResource: true });
@@ -830,7 +846,11 @@ export default class app extends Component {
   };
 
   cancelDelete = (isOpen = true) => {
-    this.setState({ toDelete: false, toDeleteResource: false });
+    this.setState({
+      toDelete: false,
+      toDeleteResource: false,
+      componentTimer: true
+    }, () => this.fetchAppDetailState(true));
   };
   closeComponentTimer = () => {
     this.setState({ componentTimer: false });

--- a/src/components/SlidePanel/components/components.js
+++ b/src/components/SlidePanel/components/components.js
@@ -37,13 +37,9 @@ import VisitBtn from '../../VisitBtn';
 import PageHeader from '../../ComponentPageHeader'
 import { rollback } from '../../../services/app';
 import appUtil from '../../../utils/app';
-import AppPubSubSocket from '../../../utils/appPubSubSocket';
 import appStatusUtil from '../../../utils/appStatus-util';
-import dateUtil from '../../../utils/date-util';
 import globalUtil from '../../../utils/global';
-import regionUtil from '../../../utils/region';
 import roleUtil from '../../../utils/newRole';
-import teamUtil from '../../../utils/team';
 import userUtil from '../../../utils/user';
 import ConnectionInformation from '../../../pages/Component/connectionInformation';
 import EnvironmentConfiguration from '../../../pages/Component/environmentConfiguration';
@@ -301,7 +297,6 @@ class Main extends PureComponent {
       BuildState: null,
       isShowThirdParty: false,
       promptModal: null,
-      websocketURL: '',
       componentTimer: true,
       tabsShow: false,
       routerSwitch: true,
@@ -312,7 +307,6 @@ class Main extends PureComponent {
       prevComponentID: globalUtil.getSlidePanelComponentID() || '', // 用于追踪 componentID 变化
     };
     this.deployRequestPending = false;
-    this.socket = null;
     this.destroy = false;
     this.statusPollingGeneration = 0;
   }
@@ -387,31 +381,10 @@ class Main extends PureComponent {
       clearTimeout(this.vmExportTimer);
       this.vmExportTimer = null;
     }
-    if (this.socket) {
-      this.socket.destroy();
-      this.socket = null;
-    }
   }
 
   onDeleteApp = () => {
     this.setState({ showDeleteApp: true });
-  }
-
-  getWebSocketUrl(service_id) {
-    const currTeam = userUtil.getTeamByTeamName(
-      this.props.currUser,
-      globalUtil.getCurrTeamName()
-    );
-    const currRegionName = globalUtil.getCurrRegionName();
-    if (currTeam) {
-      const region = teamUtil.getRegionByName(currTeam, currRegionName);
-      if (region) {
-        const websocketURL = regionUtil.getNewWebSocketUrl(region, service_id);
-        this.setState({ websocketURL }, () => {
-          this.createSocket();
-        });
-      }
-    }
   }
 
   getStatus = isCycle => {
@@ -768,8 +741,6 @@ class Main extends PureComponent {
         } else {
           this.getStatus(true);
         }
-        // get websocket url and create client
-        this.getWebSocketUrl(appDetail.service.service_id);
       },
       handleError: data => {
         if (detailGeneration !== this.statusPollingGeneration || this.destroy) {
@@ -991,21 +962,6 @@ class Main extends PureComponent {
       this.openComponentTimer();
     }
   };
-  createSocket() {
-    const { appDetail } = this.props;
-    const { websocketURL } = this.state;
-    if (websocketURL) {
-      const isThrough = dateUtil.isWebSocketOpen(websocketURL);
-      if (isThrough && isThrough === 'through') {
-        this.socket = new AppPubSubSocket({
-          url: websocketURL,
-          serviceId: appDetail.service.service_id,
-          isAutoConnect: true,
-          destroyed: false
-        });
-      }
-    }
-  }
   handleDeleteApp = () => {
     const { dispatch } = this.props;
     const { team_name, app_alias, group_id } = this.fetchParameter();
@@ -2096,7 +2052,6 @@ class Main extends PureComponent {
                   handleOperation={(msg, callback) => {
                     this.handleOperation(msg, callback);
                   }}
-                  socket={this.socket}
                   onChecked={this.handleChecked}
                   isShowUpdate={isShowUpdate}
                 />

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -231,8 +231,8 @@ export default {
         callback(response);
       }
     },
-    *fetchAppDetailState({ payload, callback }, { call }) {
-      const response = yield call(getAppDetailState, payload);
+    *fetchAppDetailState({ payload, callback, handleError }, { call }) {
+      const response = yield call(getAppDetailState, payload, handleError);
       if (response && callback) {
         callback(response);
       }

--- a/src/pages/Component/component/Basic/operationRecord.js
+++ b/src/pages/Component/component/Basic/operationRecord.js
@@ -469,7 +469,6 @@ class Index extends PureComponent {
             onCancel={this.handleCancel}
             showSocket={showSocket}
             EventID={selectEventID}
-            socket={this.props.socket}
           />
         )}
         <Modal

--- a/src/pages/Component/component/LogShow/index.js
+++ b/src/pages/Component/component/LogShow/index.js
@@ -22,15 +22,27 @@ class Index extends React.Component {
     this.state = {
       logs: [],
       dockerprogress: null,
-      status: null,
       dynamic: false
     };
     this.state.dockerprogress = new Map();
-    // 记录已渲染的无 id 日志行，避免 websocket 重放历史时重复追加
+    // 记录已渲染的无 id 日志行，避免 HTTP 快照重复追加
     this.seenMessages = new Set();
+    this.pollTimer = null;
+    this.unmounted = false;
   }
   componentDidMount() {
     this.loadEventLog();
+  }
+  componentWillUnmount() {
+    this.unmounted = true;
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    if (this.socket) {
+      this.socket.destroy();
+      this.socket = null;
+    }
   }
   shouldComponentUpdate() {
     return true;
@@ -54,7 +66,7 @@ class Index extends React.Component {
     this.props.handleCancel();
   };
   loadEventLog() {
-    const { EventID, showSocket } = this.props;
+    const { EventID, showSocket, socketUrl } = this.props;
     const teamName = globalUtil.getCurrTeamName();
     this.props.dispatch({
       type: 'appControl/fetchLogContent',
@@ -63,26 +75,45 @@ class Index extends React.Component {
         eventID: EventID
       },
       callback: res => {
+        if (this.unmounted) {
+          return;
+        }
         if (res) {
           this.setState(
             this.mergeHistoryLogs(res.list),
             () => {
-              if (showSocket) {
+              if (showSocket && socketUrl) {
                 this.showSocket();
+              } else if (showSocket) {
+                this.scheduleLogPoll();
               }
             }
           );
-        } else if (showSocket) {
+        } else if (showSocket && socketUrl) {
           this.showSocket();
+        } else if (showSocket) {
+          this.scheduleLogPoll();
         }
       }
     });
   }
-  // 历史日志去重：HTTP 拉取的历史先登记到 dockerprogress / seenMessages，
-  // 后续 websocket 建连时服务端会把同一批历史重放一遍，靠这两份登记吸收掉
+  scheduleLogPoll = () => {
+    const { showSocket, socketUrl } = this.props;
+    if (this.unmounted || !showSocket || socketUrl) {
+      return;
+    }
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+    }
+    this.pollTimer = setTimeout(() => {
+      this.pollTimer = null;
+      this.loadEventLog();
+    }, 2000);
+  };
+  // HTTP 接口返回完整日志快照，登记已显示内容后只追加新增日志。
   mergeHistoryLogs = list => {
     const { dockerprogress } = this.state;
-    const logs = [];
+    const logs = [...(this.state.logs || [])];
     (list || []).forEach(item => {
       const progress = this.parseProgressMessage(item.message);
       if (progress) {
@@ -97,7 +128,11 @@ class Index extends React.Component {
         logs.push(item);
       }
     });
-    return { logs, dockerprogress };
+    return {
+      logs,
+      dockerprogress,
+      dynamic: this.state.dynamic || this.props.showSocket
+    };
   };
   parseProgressMessage = message => {
     if (!message || message.indexOf('id') === -1) {
@@ -139,7 +174,7 @@ class Index extends React.Component {
     this.setState({ logs, dynamic: true });
   };
   showSocket() {
-    const { EventID, socket, socketUrl } = this.props;
+    const { EventID, socketUrl } = this.props;
     if (socketUrl) {
       const { onClose, onSuccess, onTimeout, onFail, onComplete } = this.props;
       const isThrough = dateUtil.isWebSocketOpen(socketUrl);
@@ -177,27 +212,12 @@ class Index extends React.Component {
           }
         });
       }
-    } else if (socket) {
-      socket.watchEventLog(
-        message => {
-          this.handleMessage(message);
-        },
-        () => {
-          this.setState({
-            status: <p style={{ color: 'green' }}>操作已成功</p>
-          });
-        },
-        () => {
-          this.setState({ status: <p style={{ color: 'red' }}>操作失败</p> });
-        },
-        EventID
-      );
     }
   }
 
   render() {
     const { title, onOk, onCancel, width } = this.props;
-    const { logs, status, dockerprogress, dynamic } = this.state;
+    const { logs, dockerprogress, dynamic } = this.state;
     let lineNumber = 0;
     let bodyText = '';
     const box = (
@@ -249,7 +269,6 @@ class Index extends React.Component {
               }
             })}
         </div>
-        {status && <div style={{ textAlign: 'center' }}>{status}</div>}
       </div>
     );
 

--- a/src/pages/Component/component/LogShow/index.node.test.js
+++ b/src/pages/Component/component/LogShow/index.node.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const source = fs.readFileSync(path.join(__dirname, 'index.js'), 'utf8');
+
+assert.ok(
+  !/watchEventLog|AppPubSubSocket/.test(source),
+  'component operation logs must not subscribe to the shared PubSub websocket'
+);
+assert.ok(
+  /scheduleLogPoll[\s\S]*?setTimeout[\s\S]*?loadEventLog\(\)[\s\S]*?2000/.test(
+    source
+  ),
+  'running operation logs should refresh through the existing HTTP loader'
+);
+assert.ok(
+  /componentWillUnmount\(\)[\s\S]*?clearTimeout\(this\.pollTimer\)/.test(source),
+  'closing the log modal must stop its HTTP polling timer'
+);
+assert.ok(
+  /showSocket\s*&&\s*socketUrl[\s\S]*?this\.showSocket\(\)/.test(source),
+  'dedicated websocket URLs used by unrelated workflows should remain supported'
+);
+
+console.log('operation log transport tests passed');

--- a/src/pages/Component/componentViewPerformance.node.test.js
+++ b/src/pages/Component/componentViewPerformance.node.test.js
@@ -20,6 +20,10 @@ const overviewSource = fs.readFileSync(
   path.join(__dirname, 'overview.js'),
   'utf8'
 );
+const legacyComponentSource = fs.readFileSync(
+  path.join(__dirname, 'index.js'),
+  'utf8'
+);
 const groupOverviewSource = fs.readFileSync(
   path.join(uiRoot, 'pages', 'Group', 'Overview.js'),
   'utf8'
@@ -163,6 +167,16 @@ assert.ok(
   /const Com = map\[currentActiveTab\]/.test(componentMainSource) &&
     /\{Com \? \(\s*<Com/.test(componentMainSource),
   'component tabs should continue to mount only the active tab'
+);
+
+assert.ok(
+  !/AppPubSubSocket|getNewWebSocketUrl|new AppPubSubSocket|socket=\{this\.socket\}/.test(
+    componentMainSource
+  ) &&
+    !/AppPubSubSocket|getNewWebSocketUrl|new AppPubSubSocket|socket=\{this\.socket\}/.test(
+      legacyComponentSource
+    ),
+  'opening component details from the topology must not create or pass a shared PubSub websocket'
 );
 
 assert.ok(

--- a/src/pages/Component/index.js
+++ b/src/pages/Component/index.js
@@ -32,7 +32,6 @@ import VisitBtn from '../../components/VisitBtn';
 import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 import { rollback } from '../../services/app';
 import appUtil from '../../utils/app';
-import AppPubSubSocket from '../../utils/appPubSubSocket';
 import appStatusUtil from '../../utils/appStatus-util';
 import ScrollerX from '../../components/ScrollerX';
 import {
@@ -41,11 +40,8 @@ import {
   createEnterprise,
   createTeam
 } from '../../utils/breadcrumb';
-import dateUtil from '../../utils/date-util';
 import globalUtil from '../../utils/global';
-import regionUtil from '../../utils/region';
 import roleUtil from '../../utils/newRole';
-import teamUtil from '../../utils/team';
 import userUtil from '../../utils/user';
 import ConnectionInformation from './connectionInformation';
 import DatabaseExpansion from './databaseExpansion';
@@ -292,7 +288,6 @@ class Main extends PureComponent {
       BuildState: null,
       isShowThirdParty: false,
       promptModal: null,
-      websocketURL: '',
       componentTimer: true,
       tabsShow: false,
       routerSwitch: true,
@@ -300,7 +295,6 @@ class Main extends PureComponent {
       componentPermissions: this.props?.componentPermissions || {},
     };
     this.deployRequestPending = false;
-    this.socket = null;
     this.destroy = false;
     this.portsAppAlias = null;
   }
@@ -329,10 +323,6 @@ class Main extends PureComponent {
       clearTimeout(this.vmExportTimer);
       this.vmExportTimer = null;
     }
-    if (this.socket) {
-      this.socket.destroy();
-      this.socket = null;
-    }
     this.destroy = true;
   }
 
@@ -347,23 +337,6 @@ class Main extends PureComponent {
       })
     }
   };
-
-  getWebSocketUrl(service_id) {
-    const currTeam = userUtil.getTeamByTeamName(
-      this.props.currUser,
-      globalUtil.getCurrTeamName()
-    );
-    const currRegionName = globalUtil.getCurrRegionName();
-    if (currTeam) {
-      const region = teamUtil.getRegionByName(currTeam, currRegionName);
-      if (region) {
-        const websocketURL = regionUtil.getNewWebSocketUrl(region, service_id);
-        this.setState({ websocketURL }, () => {
-          this.createSocket();
-        });
-      }
-    }
-  }
 
   getStatus = isCycle => {
     const { dispatch } = this.props;
@@ -612,8 +585,6 @@ class Main extends PureComponent {
         } else {
           this.getStatus(false);
         }
-        // get websocket url and create client
-        this.getWebSocketUrl(appDetail.service.service_id);
       },
       handleError: data => {
         const { componentTimer } = this.state;
@@ -809,21 +780,6 @@ class Main extends PureComponent {
       this.openComponentTimer();
     }
   };
-  createSocket() {
-    const { appDetail } = this.props;
-    const { websocketURL } = this.state;
-    if (websocketURL) {
-      const isThrough = dateUtil.isWebSocketOpen(websocketURL);
-      if (isThrough && isThrough === 'through') {
-        this.socket = new AppPubSubSocket({
-          url: websocketURL,
-          serviceId: appDetail.service.service_id,
-          isAutoConnect: true,
-          destroyed: false
-        });
-      }
-    }
-  }
   handleDeleteApp = () => {
     const { dispatch } = this.props;
     const { team_name, app_alias, group_id } = this.fetchParameter();
@@ -1808,7 +1764,6 @@ class Main extends PureComponent {
               onshowRestartTips={msg => {
                 this.handleshowRestartTips(msg);
               }}
-              socket={this.socket}
               onChecked={this.handleChecked}
             />
           ) : (

--- a/src/pages/Group/Overview.js
+++ b/src/pages/Group/Overview.js
@@ -317,6 +317,7 @@ export default class Overview extends Component {
     return (
       <div className={`${styles.headerWrapper} ${!isVisible ? styles.headerShow : styles.headerHide}`}>
         <AppHeader
+          apps={this.state.apps}
           addComponentOrAppDetail={this.state.addComponentOrAppDetail}
           handleAddComponentOrAppDetail={this.handleAddComponentOrAppDetail}
           permissions={{

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -326,9 +326,13 @@ export async function getUpgradeComponentList(body = {}, handleError) {
 /*
 	获取某个应用组的信息
 */
-export async function getAppDetailState(body = {}) {
+export async function getAppDetailState(body = {}, handleError) {
   return request(
-    `${apiconfig.baseUrl}/console/teams/${body.team_name}/groups/${body.group_id}/status`
+    `${apiconfig.baseUrl}/console/teams/${body.team_name}/groups/${body.group_id}/status`,
+    {
+      handleError,
+      showLoading: false
+    }
   );
 }
 /*


### PR DESCRIPTION
## Summary

- reuse loaded component data and reduce application status/operator polling frequency
- pause topology-related polling while the page is hidden and prevent overlapping requests
- remove the obsolete shared component PubSub WebSocket from topology/component detail flows
- refresh running operation logs through the existing HTTP log endpoint while the modal is open
- keep runtime logs on SSE, monitoring on HTTP, and web terminal WebSocket behavior unchanged

## Verification

- node src/pages/Component/component/LogShow/index.node.test.js
- node src/pages/Component/componentViewPerformance.node.test.js
- node src/pages/Component/component/Basic/operationRecordHelpers.node.test.js
- yarn build (compiled successfully with 0 warnings)