### PR TITLE
fix: stream component operation logs over SSE

### DIFF
--- a/src/components/SlidePanel/components/app.js
+++ b/src/components/SlidePanel/components/app.js
@@ -12,7 +12,6 @@ import { buildApp } from '../../../services/createApp';
 import VisterBtnWithIcon from './VisterBtnWithIcon';
 import AppDeteleResource from '../../../components/AppDeteleResource'
 import RapidCopy from '../../../components/RapidCopy';
-import cookie from '../../../utils/cookie';
 import { FormattedMessage } from 'umi';
 import { formatMessage } from '@/utils/intl';
 import pageheaderSvg from '@/utils/pageHeaderSvg';
@@ -28,7 +27,7 @@ import { shouldLoadStorageUsage } from './componentViewPerformance';
   editGroupLoading: loading.effects['application/editGroup'],
   deleteLoading: loading.effects['application/deleteGroupAllResource'],
   currUser: user.currentUser,
-  apps: application.apps,
+  storeApps: application.apps,
   groupDetail: application.groupDetail || {},
   currentTeam: teamControl.currentTeam,
   currentRegionName: teamControl.currentRegionName,
@@ -74,16 +73,19 @@ export default class app extends Component {
       
     };
     this.storageUsageRequested = false;
+    this.statusRequestInFlight = false;
+    this.operatorRequestInFlight = false;
+    this.componentMounted = false;
   }
   componentDidMount() {
     if (!globalUtil.getAppID()) {
       return;
     }
+    this.componentMounted = true;
     this.loading();
-    this.handleArchCpuInfo();
     this.handleWaitLevel();
-    this.handleGroupAllResource()
     this.loadStorageUsageIfNeeded(this.props.pluginsList);
+    document.addEventListener('visibilitychange', this.handleVisibilityChange);
   }
   componentDidUpdate(prevProps) {
     if (prevProps.permissions !== this.props.permissions) {
@@ -94,34 +96,21 @@ export default class app extends Component {
     if (prevProps.pluginsList !== this.props.pluginsList) {
       this.loadStorageUsageIfNeeded(this.props.pluginsList);
     }
+    if (prevProps.apps !== this.props.apps || prevProps.storeApps !== this.props.storeApps) {
+      this.syncComponentSummary(this.getComponents());
+    }
   }
   loading = () => {
     this.fetchAppDetail();
-    this.loadTopology(true);
-    this.fetchAppDetailState();
-    this.getOperator();
+    this.syncComponentSummary(this.getComponents());
+    this.fetchAppDetailState(true);
+    this.getOperator(true);
   };
   componentWillUnmount() {
+    this.componentMounted = false;
     this.closeTimer();
+    document.removeEventListener('visibilitychange', this.handleVisibilityChange);
   };
-  // 获取集群架构信息
-  handleArchCpuInfo = () => {
-    const { dispatch } = this.props;
-    dispatch({
-      type: 'index/fetchArchOverview',
-      payload: {
-        region_name: globalUtil.getCurrRegionName(),
-        team_name: globalUtil.getCurrTeamName()
-      },
-      callback: res => {
-        if (res && res.bean) {
-          this.setState({
-            archInfo: res.list
-          })
-        }
-      }
-    });
-  }
   handleWaitLevel = () => {
     const { dispatch } = this.props;
     dispatch({
@@ -185,7 +174,11 @@ export default class app extends Component {
       }
     });
   };
-  fetchAppDetailState = () => {
+  fetchAppDetailState = (isCycle = false) => {
+    if (this.statusRequestInFlight) {
+      return;
+    }
+    this.statusRequestInFlight = true;
     const { dispatch } = this.props;
     dispatch({
       type: 'application/fetchAppDetailState',
@@ -194,14 +187,66 @@ export default class app extends Component {
         group_id: globalUtil.getAppID()
       },
       callback: res => {
+        this.statusRequestInFlight = false;
+        if (!this.componentMounted) {
+          return;
+        }
         this.setState({
           resources: res.list,
           appStatusConfig: true
         });
+        if (isCycle) {
+          this.scheduleStatusRefresh();
+        }
+      },
+      handleError: err => {
+        this.statusRequestInFlight = false;
+        if (!this.componentMounted) {
+          return;
+        }
+        this.handleError(err);
+        if (isCycle) {
+          this.scheduleStatusRefresh(20000);
+        }
       }
     });
   };
-  getOperator = () => {
+  scheduleStatusRefresh = (delay = 15000) => {
+    if (this.statusTimer) {
+      clearTimeout(this.statusTimer);
+    }
+    if (!this.componentMounted || !this.state.componentTimer) {
+      return;
+    }
+    this.statusTimer = setTimeout(() => {
+      if (document.hidden) {
+        this.scheduleStatusRefresh(delay);
+        return;
+      }
+      this.fetchAppDetailState(true);
+    }, delay);
+  };
+  handleVisibilityChange = () => {
+    if (!this.componentMounted || !this.state.componentTimer) {
+      return;
+    }
+    if (document.hidden) {
+      if (this.statusTimer) {
+        clearTimeout(this.statusTimer);
+      }
+      if (this.operatorTimer) {
+        clearTimeout(this.operatorTimer);
+      }
+      return;
+    }
+    this.fetchAppDetailState(true);
+    this.getOperator(true);
+  };
+  getOperator = (isCycle = false) => {
+    if (this.operatorRequestInFlight) {
+      return;
+    }
+    this.operatorRequestInFlight = true;
     const { dispatch } = this.props;
     dispatch({
       type: 'application/getOperator',
@@ -210,6 +255,10 @@ export default class app extends Component {
         group_id: globalUtil.getAppID(),
       },
       callback: data => {
+        this.operatorRequestInFlight = false;
+        if (!this.componentMounted) {
+          return;
+        }
         if (data && data.status_code == 200) {
           const arr = data.list.service
           if (arr && arr.length > 0) {
@@ -267,8 +316,36 @@ export default class app extends Component {
             })
           }
         }
+        if (isCycle) {
+          this.scheduleOperatorRefresh();
+        }
+      },
+      handleError: err => {
+        this.operatorRequestInFlight = false;
+        if (!this.componentMounted) {
+          return;
+        }
+        this.handleError(err);
+        if (isCycle) {
+          this.scheduleOperatorRefresh();
+        }
       }
     });
+  };
+  scheduleOperatorRefresh = (delay = 60000) => {
+    if (this.operatorTimer) {
+      clearTimeout(this.operatorTimer);
+    }
+    if (!this.componentMounted || !this.state.componentTimer) {
+      return;
+    }
+    this.operatorTimer = setTimeout(() => {
+      if (document.hidden) {
+        this.scheduleOperatorRefresh(delay);
+        return;
+      }
+      this.getOperator(true);
+    }, delay);
   };
   // 获取存储实际占用
   loadStorageUsageIfNeeded = pluginsList => {
@@ -296,54 +373,28 @@ export default class app extends Component {
       }
     });
   }
-  loadTopology(isCycle) {
-    const { dispatch } = this.props;
-    const teamName = globalUtil.getCurrTeamName();
-    const regionName = globalUtil.getCurrRegionName();
-    cookie.set('team_name', teamName);
-    cookie.set('region_name', regionName);
+  getComponents = () => this.props.apps || this.props.storeApps || [];
+  syncComponentSummary = (apps = []) => {
+    const components = apps || [];
+    const serviceIds = components
+      .map(component => component && component.service_id)
+      .filter(Boolean);
+    const service_alias = components
+      .map(component => component && component.service_alias)
+      .filter(Boolean);
 
-    dispatch({
-      type: 'global/fetAllTopology',
-      payload: {
-        region_name: regionName,
-        team_name: teamName,
-        groupId: globalUtil.getAppID()
-      },
-      callback: res => {
-        if (res && res.status_code === 200) {
-          const data = res.bean;
-          if (JSON.stringify(data) === '{}') {
-            return;
-          }
-          const serviceIds = [];
-          const service_alias = [];
-          const { json_data } = data;
-          Object.keys(json_data).map(key => {
-            serviceIds.push(key);
-            if (
-              json_data[key].cur_status == 'running' &&
-              json_data[key].is_internet == true
-            ) {
-              service_alias.push(json_data[key].service_alias);
-            }
-          });
-
-          this.setState(
-            {
-              jsonDataLength: Object.keys(json_data).length,
-              service_alias,
-              serviceIds
-            },
-            () => {
-              this.loadLinks(service_alias.join('-'), isCycle);
-            }
-          );
-        }
-      }
+    this.setState({
+      jsonDataLength: components.length,
+      service_alias,
+      serviceIds
     });
-  }
-  loadLinks(serviceAlias, isCycle) {
+    if (service_alias.length > 0) {
+      this.loadLinks(service_alias.join('-'));
+    } else {
+      this.setState({ linkList: [] });
+    }
+  };
+  loadLinks(serviceAlias) {
     const { dispatch } = this.props;
     dispatch({
       type: 'global/queryLinks',
@@ -353,42 +404,13 @@ export default class app extends Component {
       },
       callback: res => {
         if (res && res.status_code === 200) {
-          this.setState(
-            {
-              linkList: res.list || []
-            },
-            () => {
-              if (isCycle) {
-                this.handleTimers(
-                  'timer',
-                  () => {
-                    this.fetchAppDetailState();
-                    this.fetchAppDetail();
-                    this.loadTopology(true);
-                    this.getOperator();
-                  },
-                  10000
-                );
-                setTimeout(() => {
-                  this.checkPermissions();
-                }, 100)
-              }
-            }
-          );
+          this.setState({
+            linkList: res.list || []
+          });
         }
       },
       handleError: err => {
         this.handleError(err);
-        this.handleTimers(
-          'timer',
-          () => {
-            this.fetchAppDetailState();
-            this.fetchAppDetail();
-            this.loadTopology(true);
-            this.getOperator();
-          },
-          20000
-        );
       }
     });
   }
@@ -404,21 +426,15 @@ export default class app extends Component {
       });
     }
   };
-  handleTimers = (timerName, callback, times) => {
-    const { componentTimer } = this.state;
-    if (!componentTimer) {
-      return null;
-    }
-    this[timerName] = setTimeout(() => {
-      if (!globalUtil.getAppID()) {
-        return;
-      }
-      callback();
-    }, times);
-  };
   closeTimer = () => {
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer);
+    }
+    if (this.statusTimer) {
+      clearTimeout(this.statusTimer);
+    }
+    if (this.operatorTimer) {
+      clearTimeout(this.operatorTimer);
     }
   };
   // 根据权限判断是否显示
@@ -779,7 +795,7 @@ export default class app extends Component {
           });
           this.handlePromptModalClose();
         }
-        this.loadTopology(false);
+        this.fetchAppDetailState(true);
       });
     } else {
       dispatch({
@@ -797,7 +813,7 @@ export default class app extends Component {
             });
             this.handlePromptModalClose();
           }
-          this.loadTopology(false);
+          this.fetchAppDetailState(true);
         }
       });
     }
@@ -815,7 +831,7 @@ export default class app extends Component {
   };
   toDelete = () => {
     this.closeComponentTimer();
-    this.setState({ toDelete: true });
+    this.setState({ toDelete: true }, this.handleGroupAllResource);
   };
   toDeleteResource = () => {
     this.setState({ toDeleteResource: true });
@@ -830,7 +846,11 @@ export default class app extends Component {
   };
 
   cancelDelete = (isOpen = true) => {
-    this.setState({ toDelete: false, toDeleteResource: false });
+    this.setState({
+      toDelete: false,
+      toDeleteResource: false,
+      componentTimer: true
+    }, () => this.fetchAppDetailState(true));
   };
   closeComponentTimer = () => {
     this.setState({ componentTimer: false });

--- a/src/components/SlidePanel/components/components.js
+++ b/src/components/SlidePanel/components/components.js
@@ -37,13 +37,9 @@ import VisitBtn from '../../VisitBtn';
 import PageHeader from '../../ComponentPageHeader'
 import { rollback } from '../../../services/app';
 import appUtil from '../../../utils/app';
-import AppPubSubSocket from '../../../utils/appPubSubSocket';
 import appStatusUtil from '../../../utils/appStatus-util';
-import dateUtil from '../../../utils/date-util';
 import globalUtil from '../../../utils/global';
-import regionUtil from '../../../utils/region';
 import roleUtil from '../../../utils/newRole';
-import teamUtil from '../../../utils/team';
 import userUtil from '../../../utils/user';
 import ConnectionInformation from '../../../pages/Component/connectionInformation';
 import EnvironmentConfiguration from '../../../pages/Component/environmentConfiguration';
@@ -301,7 +297,6 @@ class Main extends PureComponent {
       BuildState: null,
       isShowThirdParty: false,
       promptModal: null,
-      websocketURL: '',
       componentTimer: true,
       tabsShow: false,
       routerSwitch: true,
@@ -312,7 +307,6 @@ class Main extends PureComponent {
       prevComponentID: globalUtil.getSlidePanelComponentID() || '', // 用于追踪 componentID 变化
     };
     this.deployRequestPending = false;
-    this.socket = null;
     this.destroy = false;
     this.statusPollingGeneration = 0;
   }
@@ -387,31 +381,10 @@ class Main extends PureComponent {
       clearTimeout(this.vmExportTimer);
       this.vmExportTimer = null;
     }
-    if (this.socket) {
-      this.socket.destroy();
-      this.socket = null;
-    }
   }
 
   onDeleteApp = () => {
     this.setState({ showDeleteApp: true });
-  }
-
-  getWebSocketUrl(service_id) {
-    const currTeam = userUtil.getTeamByTeamName(
-      this.props.currUser,
-      globalUtil.getCurrTeamName()
-    );
-    const currRegionName = globalUtil.getCurrRegionName();
-    if (currTeam) {
-      const region = teamUtil.getRegionByName(currTeam, currRegionName);
-      if (region) {
-        const websocketURL = regionUtil.getNewWebSocketUrl(region, service_id);
-        this.setState({ websocketURL }, () => {
-          this.createSocket();
-        });
-      }
-    }
   }
 
   getStatus = isCycle => {
@@ -768,8 +741,6 @@ class Main extends PureComponent {
         } else {
           this.getStatus(true);
         }
-        // get websocket url and create client
-        this.getWebSocketUrl(appDetail.service.service_id);
       },
       handleError: data => {
         if (detailGeneration !== this.statusPollingGeneration || this.destroy) {
@@ -991,21 +962,6 @@ class Main extends PureComponent {
       this.openComponentTimer();
     }
   };
-  createSocket() {
-    const { appDetail } = this.props;
-    const { websocketURL } = this.state;
-    if (websocketURL) {
-      const isThrough = dateUtil.isWebSocketOpen(websocketURL);
-      if (isThrough && isThrough === 'through') {
-        this.socket = new AppPubSubSocket({
-          url: websocketURL,
-          serviceId: appDetail.service.service_id,
-          isAutoConnect: true,
-          destroyed: false
-        });
-      }
-    }
-  }
   handleDeleteApp = () => {
     const { dispatch } = this.props;
     const { team_name, app_alias, group_id } = this.fetchParameter();
@@ -2096,7 +2052,6 @@ class Main extends PureComponent {
                   handleOperation={(msg, callback) => {
                     this.handleOperation(msg, callback);
                   }}
-                  socket={this.socket}
                   onChecked={this.handleChecked}
                   isShowUpdate={isShowUpdate}
                 />

--- a/src/models/application.js
+++ b/src/models/application.js
@@ -231,8 +231,8 @@ export default {
         callback(response);
       }
     },
-    *fetchAppDetailState({ payload, callback }, { call }) {
-      const response = yield call(getAppDetailState, payload);
+    *fetchAppDetailState({ payload, callback, handleError }, { call }) {
+      const response = yield call(getAppDetailState, payload, handleError);
       if (response && callback) {
         callback(response);
       }

--- a/src/pages/Component/component/Basic/operationRecord.js
+++ b/src/pages/Component/component/Basic/operationRecord.js
@@ -28,7 +28,7 @@ class Index extends PureComponent {
     this.state = {
       logVisible: false,
       selectEventID: '',
-      showSocket: false,
+      showEventStream: false,
       isLoadingMore: false
     };
     this.sentinelRef = React.createRef();
@@ -117,7 +117,7 @@ class Index extends PureComponent {
     }
   };
 
-  showLogModal = (event_id, showSocket, opt_type = '') => {
+  showLogModal = (event_id, showEventStream, opt_type = '') => {
     const { isopenLog, onLogPush } = this.props;
     if (isopenLog && onLogPush) {
       onLogPush(false);
@@ -125,7 +125,7 @@ class Index extends PureComponent {
     this.setState({
       logVisible: true,
       selectEventID: event_id,
-      showSocket
+      showEventStream
     });
   };
 
@@ -265,7 +265,7 @@ class Index extends PureComponent {
 
   render() {
     const { logList, has_next, recordLoading, isopenLog } = this.props;
-    const { logVisible, selectEventID, showSocket, showModalArr, showModal, isLoadingMore } = this.state;
+    const { logVisible, selectEventID, showEventStream, showModalArr, showModal, isLoadingMore } = this.state;
     let showLogEvent = '';
     let hasShownFailureLogTip = false;
     return (
@@ -467,9 +467,8 @@ class Index extends PureComponent {
             width="90%"
             onOk={this.handleCancel}
             onCancel={this.handleCancel}
-            showSocket={showSocket}
+            showEventStream={showEventStream}
             EventID={selectEventID}
-            socket={this.props.socket}
           />
         )}
         <Modal

--- a/src/pages/Component/component/LogShow/eventLogStreamHelpers.js
+++ b/src/pages/Component/component/LogShow/eventLogStreamHelpers.js
@@ -1,0 +1,23 @@
+function buildEventLogStreamUrl(eventID, regionName) {
+  return `/console/sse/v2/events/${encodeURIComponent(
+    eventID
+  )}/stream?region_name=${encodeURIComponent(regionName)}`;
+}
+
+function getEventLogTerminalState(message) {
+  if (!message) {
+    return null;
+  }
+  if (message.step === 'last') {
+    return 'success';
+  }
+  if (message.step === 'callback') {
+    return 'failure';
+  }
+  return null;
+}
+
+module.exports = {
+  buildEventLogStreamUrl,
+  getEventLogTerminalState
+};

--- a/src/pages/Component/component/LogShow/eventLogStreamHelpers.js
+++ b/src/pages/Component/component/LogShow/eventLogStreamHelpers.js
@@ -17,7 +17,19 @@ function getEventLogTerminalState(message) {
   return null;
 }
 
+function shouldAppendEventLog(message, seenMessages, deduplicateMessages) {
+  if (!deduplicateMessages) {
+    return true;
+  }
+  if (seenMessages.has(message)) {
+    return false;
+  }
+  seenMessages.add(message);
+  return true;
+}
+
 module.exports = {
   buildEventLogStreamUrl,
-  getEventLogTerminalState
+  getEventLogTerminalState,
+  shouldAppendEventLog
 };

--- a/src/pages/Component/component/LogShow/eventLogStreamHelpers.node.test.js
+++ b/src/pages/Component/component/LogShow/eventLogStreamHelpers.node.test.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const {
+  buildEventLogStreamUrl,
+  getEventLogTerminalState
+} = require('./eventLogStreamHelpers');
+
+assert.strictEqual(
+  buildEventLogStreamUrl('event#id', 'region&name=1'),
+  '/console/sse/v2/events/event%23id/stream?region_name=region%26name%3D1',
+  'should reuse the generic SSE proxy and encode its event and region values'
+);
+
+assert.strictEqual(
+  getEventLogTerminalState({ step: 'last' }),
+  'success',
+  'last should preserve the successful PubSub terminal meaning'
+);
+assert.strictEqual(
+  getEventLogTerminalState({ step: 'callback' }),
+  'failure',
+  'callback should preserve the failed PubSub terminal meaning'
+);
+assert.strictEqual(
+  getEventLogTerminalState({ step: 'build' }),
+  null,
+  'ordinary event messages should not be terminal'
+);
+assert.strictEqual(
+  getEventLogTerminalState(null),
+  null,
+  'missing event messages should not be terminal'
+);
+
+console.log('event log stream helper tests passed');

--- a/src/pages/Component/component/LogShow/eventLogStreamHelpers.node.test.js
+++ b/src/pages/Component/component/LogShow/eventLogStreamHelpers.node.test.js
@@ -1,7 +1,8 @@
 const assert = require('assert');
 const {
   buildEventLogStreamUrl,
-  getEventLogTerminalState
+  getEventLogTerminalState,
+  shouldAppendEventLog
 } = require('./eventLogStreamHelpers');
 
 assert.strictEqual(
@@ -29,6 +30,31 @@ assert.strictEqual(
   getEventLogTerminalState(null),
   null,
   'missing event messages should not be terminal'
+);
+
+const repeatedMessage = 'the same valid log line';
+const operationLogMessages = new Set();
+assert.strictEqual(
+  shouldAppendEventLog(repeatedMessage, operationLogMessages, false),
+  true,
+  'operation and build logs should append the first ordinary log line'
+);
+assert.strictEqual(
+  shouldAppendEventLog(repeatedMessage, operationLogMessages, false),
+  true,
+  'operation and build logs should preserve identical ordinary log lines'
+);
+
+const appShareMessages = new Set();
+assert.strictEqual(
+  shouldAppendEventLog(repeatedMessage, appShareMessages, true),
+  true,
+  'the dedicated app-share socket should keep its first ordinary log line'
+);
+assert.strictEqual(
+  shouldAppendEventLog(repeatedMessage, appShareMessages, true),
+  false,
+  'the dedicated app-share socket should retain its existing replay deduplication'
 );
 
 console.log('event log stream helper tests passed');

--- a/src/pages/Component/component/LogShow/index.js
+++ b/src/pages/Component/component/LogShow/index.js
@@ -8,7 +8,8 @@ import globalUtil from '../../../../utils/global';
 import LogSocket from '../../../../utils/logSocket';
 import {
   buildEventLogStreamUrl,
-  getEventLogTerminalState
+  getEventLogTerminalState,
+  shouldAppendEventLog
 } from './eventLogStreamHelpers';
 import styles from './index.less';
 
@@ -30,7 +31,7 @@ class Index extends React.Component {
       dynamic: false
     };
     this.state.dockerprogress = new Map();
-    // 记录已渲染的无 id 日志行，避免实时连接重放历史时重复追加
+    // 仅供需要保留历史行为的独立 WebSocket 日志去重
     this.seenMessages = new Set();
     this.eventSource = null;
     this.socket = null;
@@ -97,10 +98,11 @@ class Index extends React.Component {
       this.showSocket();
     }
   };
-  // 历史日志去重：HTTP 拉取的历史先登记到 dockerprogress / seenMessages，
-  // 后续实时连接建连时服务端会把同一批历史重放一遍，靠这两份登记吸收掉
+  // progress.id 保持覆盖更新；普通日志默认全部保留。
+  // AppShareLoading 的独立 WebSocket 通过显式 prop 保留原去重行为。
   mergeHistoryLogs = list => {
     const { dockerprogress } = this.state;
+    const { deduplicateMessages } = this.props;
     const logs = [];
     (list || []).forEach(item => {
       const progress = this.parseProgressMessage(item.message);
@@ -111,8 +113,13 @@ class Index extends React.Component {
         dockerprogress.set(progress.id, progress);
         return;
       }
-      if (!this.seenMessages.has(item.message)) {
-        this.seenMessages.add(item.message);
+      if (
+        shouldAppendEventLog(
+          item.message,
+          this.seenMessages,
+          deduplicateMessages
+        )
+      ) {
         logs.push(item);
       }
     });
@@ -133,29 +140,34 @@ class Index extends React.Component {
     return null;
   };
   handleMessage = data => {
-    const logs = this.state.logs || [];
+    const { deduplicateMessages } = this.props;
     const progress = this.parseProgressMessage(data.message);
-    if (progress) {
-      const { dockerprogress } = this.state;
-      if (dockerprogress.get(progress.id) === undefined) {
-        logs.push(data);
+    this.setState(
+      prevState => {
+        const logs = [...(prevState.logs || [])];
+        const dockerprogress = new Map(prevState.dockerprogress);
+        if (progress) {
+          if (dockerprogress.get(progress.id) === undefined) {
+            logs.push(data);
+          }
+          dockerprogress.set(progress.id, progress);
+        } else if (
+          shouldAppendEventLog(
+            data.message,
+            this.seenMessages,
+            deduplicateMessages
+          )
+        ) {
+          logs.push(data);
+        }
+        return { dockerprogress, logs, dynamic: true };
+      },
+      () => {
+        if (this.refs.box) {
+          this.refs.box.scrollTop = this.refs.box.scrollHeight;
+        }
       }
-      dockerprogress.set(progress.id, progress);
-      this.setState({
-        dockerprogress,
-        logs,
-        dynamic: true
-      });
-      return;
-    }
-    if (!this.seenMessages.has(data.message)) {
-      this.seenMessages.add(data.message);
-      logs.push(data);
-    }
-    if (this.refs.box) {
-      this.refs.box.scrollTop = this.refs.box.scrollHeight;
-    }
-    this.setState({ logs, dynamic: true });
+    );
   };
   openEventStream = () => {
     const { EventID } = this.props;

--- a/src/pages/Component/component/LogShow/index.js
+++ b/src/pages/Component/component/LogShow/index.js
@@ -6,6 +6,10 @@ import Ansi from '../../../../components/Ansi';
 import dateUtil from '../../../../utils/date-util';
 import globalUtil from '../../../../utils/global';
 import LogSocket from '../../../../utils/logSocket';
+import {
+  buildEventLogStreamUrl,
+  getEventLogTerminalState
+} from './eventLogStreamHelpers';
 import styles from './index.less';
 
 @connect(
@@ -26,11 +30,22 @@ class Index extends React.Component {
       dynamic: false
     };
     this.state.dockerprogress = new Map();
-    // 记录已渲染的无 id 日志行，避免 websocket 重放历史时重复追加
+    // 记录已渲染的无 id 日志行，避免实时连接重放历史时重复追加
     this.seenMessages = new Set();
+    this.eventSource = null;
+    this.socket = null;
+    this.unmounted = false;
   }
   componentDidMount() {
     this.loadEventLog();
+  }
+  componentWillUnmount() {
+    this.unmounted = true;
+    this.closeEventSource();
+    if (this.socket) {
+      this.socket.destroy();
+      this.socket = null;
+    }
   }
   shouldComponentUpdate() {
     return true;
@@ -54,7 +69,7 @@ class Index extends React.Component {
     this.props.handleCancel();
   };
   loadEventLog() {
-    const { EventID, showSocket } = this.props;
+    const { EventID } = this.props;
     const teamName = globalUtil.getCurrTeamName();
     this.props.dispatch({
       type: 'appControl/fetchLogContent',
@@ -64,22 +79,26 @@ class Index extends React.Component {
       },
       callback: res => {
         if (res) {
-          this.setState(
-            this.mergeHistoryLogs(res.list),
-            () => {
-              if (showSocket) {
-                this.showSocket();
-              }
-            }
-          );
-        } else if (showSocket) {
-          this.showSocket();
+          this.setState(this.mergeHistoryLogs(res.list), this.startRealtimeLog);
+        } else {
+          this.startRealtimeLog();
         }
       }
     });
   }
+  startRealtimeLog = () => {
+    if (this.unmounted) {
+      return;
+    }
+    const { showEventStream, showSocket, socketUrl } = this.props;
+    if (showEventStream) {
+      this.openEventStream();
+    } else if (showSocket && socketUrl) {
+      this.showSocket();
+    }
+  };
   // 历史日志去重：HTTP 拉取的历史先登记到 dockerprogress / seenMessages，
-  // 后续 websocket 建连时服务端会把同一批历史重放一遍，靠这两份登记吸收掉
+  // 后续实时连接建连时服务端会把同一批历史重放一遍，靠这两份登记吸收掉
   mergeHistoryLogs = list => {
     const { dockerprogress } = this.state;
     const logs = [];
@@ -138,8 +157,42 @@ class Index extends React.Component {
     }
     this.setState({ logs, dynamic: true });
   };
+  openEventStream = () => {
+    const { EventID } = this.props;
+    const regionName = globalUtil.getCurrRegionName();
+    const url = buildEventLogStreamUrl(EventID, regionName);
+    this.closeEventSource();
+    this.eventSource = new EventSource(url, { withCredentials: true });
+    this.eventSource.onmessage = event => {
+      let message;
+      try {
+        message = JSON.parse(event.data);
+      } catch (err) {
+        return;
+      }
+      this.handleMessage(message);
+      const terminalState = getEventLogTerminalState(message);
+      if (terminalState) {
+        this.setState({
+          status:
+            terminalState === 'success' ? (
+              <p style={{ color: 'green' }}>操作已成功</p>
+            ) : (
+              <p style={{ color: 'red' }}>操作失败</p>
+            )
+        });
+        this.closeEventSource();
+      }
+    };
+  };
+  closeEventSource = () => {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+  };
   showSocket() {
-    const { EventID, socket, socketUrl } = this.props;
+    const { EventID, socketUrl } = this.props;
     if (socketUrl) {
       const { onClose, onSuccess, onTimeout, onFail, onComplete } = this.props;
       const isThrough = dateUtil.isWebSocketOpen(socketUrl);
@@ -177,21 +230,6 @@ class Index extends React.Component {
           }
         });
       }
-    } else if (socket) {
-      socket.watchEventLog(
-        message => {
-          this.handleMessage(message);
-        },
-        () => {
-          this.setState({
-            status: <p style={{ color: 'green' }}>操作已成功</p>
-          });
-        },
-        () => {
-          this.setState({ status: <p style={{ color: 'red' }}>操作失败</p> });
-        },
-        EventID
-      );
     }
   }
 

--- a/src/pages/Component/component/LogShow/index.node.test.js
+++ b/src/pages/Component/component/LogShow/index.node.test.js
@@ -7,6 +7,14 @@ const operationRecordSource = fs.readFileSync(
   path.join(__dirname, '..', 'Basic', 'operationRecord.js'),
   'utf8'
 );
+const buildHistorySource = fs.readFileSync(
+  path.join(__dirname, '..', 'BuildHistory', 'index.js'),
+  'utf8'
+);
+const appShareLoadingSource = fs.readFileSync(
+  path.join(__dirname, '..', '..', '..', 'Group', 'AppShareLoading.js'),
+  'utf8'
+);
 
 assert.ok(
   /buildEventLogStreamUrl/.test(logShowSource) &&
@@ -48,6 +56,31 @@ assert.ok(
 assert.ok(
   /socketUrl/.test(logShowSource) && /new LogSocket/.test(logShowSource),
   'the dedicated AppShareLoading LogSocket branch must remain available'
+);
+assert.ok(
+  /shouldAppendEventLog\(\s*data\.message,\s*this\.seenMessages,\s*deduplicateMessages\s*\)/.test(
+    logShowSource
+  ) &&
+    !/deduplicateMessages/.test(operationRecordSource) &&
+    !/deduplicateMessages/.test(buildHistorySource),
+  'operation records and build history should preserve repeated ordinary log lines'
+);
+assert.ok(
+  /<LogShow[\s\S]*?deduplicateMessages[\s\S]*?socketUrl=\{this\.socketUrl\}/.test(
+    appShareLoadingSource
+  ),
+  'AppShareLoading should explicitly retain ordinary-message replay deduplication'
+);
+assert.ok(
+  /dockerprogress\.get\(progress\.id\)/.test(logShowSource) &&
+    /dockerprogress\.set\(progress\.id, progress\)/.test(logShowSource),
+  'progress messages should continue to update by progress id'
+);
+assert.ok(
+  /handleMessage = data => \{[\s\S]*?this\.setState\(\s*prevState => \{[\s\S]*?\.\.\.\(prevState\.logs \|\| \[\]\)[\s\S]*?new Map\(prevState\.dockerprogress\)/.test(
+    logShowSource
+  ) && !/const logs = this\.state\.logs/.test(logShowSource),
+  'realtime log updates should copy state inside functional setState'
 );
 assert.ok(
   ![

--- a/src/pages/Component/component/LogShow/index.node.test.js
+++ b/src/pages/Component/component/LogShow/index.node.test.js
@@ -1,0 +1,66 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const logShowSource = fs.readFileSync(path.join(__dirname, 'index.js'), 'utf8');
+const operationRecordSource = fs.readFileSync(
+  path.join(__dirname, '..', 'Basic', 'operationRecord.js'),
+  'utf8'
+);
+
+assert.ok(
+  /buildEventLogStreamUrl/.test(logShowSource) &&
+    /getEventLogTerminalState/.test(logShowSource),
+  'LogShow should build and classify the event stream with pure helpers'
+);
+assert.ok(
+  /const \{ EventID \} = this\.props;[\s\S]*?buildEventLogStreamUrl\(EventID, regionName\)/.test(
+    logShowSource
+  ) &&
+    !/buildEventLogStreamUrl\([\s\S]{0,120}serviceAlias/.test(logShowSource),
+  'LogShow should reuse the generic SSE proxy without component route plumbing'
+);
+assert.ok(
+  /new EventSource\(url,\s*\{\s*withCredentials:\s*true\s*\}\)/.test(
+    logShowSource
+  ),
+  'running operation logs should open a credentialed EventSource'
+);
+assert.ok(
+  /JSON\.parse\(event\.data\)/.test(logShowSource) &&
+    /getEventLogTerminalState\(message\)/.test(logShowSource),
+  'SSE data frames should be parsed and checked for terminal messages'
+);
+assert.ok(
+  /closeEventSource\s*=/.test(logShowSource) &&
+    /componentWillUnmount\(\)[\s\S]*?this\.closeEventSource\(\)/.test(
+      logShowSource
+    ) &&
+    /if \(terminalState\)[\s\S]*?this\.closeEventSource\(\)/.test(
+      logShowSource
+    ),
+  'terminal messages and component unmount should close the EventSource'
+);
+assert.ok(
+  !logShowSource.includes(`watchEvent${'Log'}`),
+  'LogShow must not use the removed shared PubSub subscription'
+);
+assert.ok(
+  /socketUrl/.test(logShowSource) && /new LogSocket/.test(logShowSource),
+  'the dedicated AppShareLoading LogSocket branch must remain available'
+);
+assert.ok(
+  ![
+    `scheduleLog${'Poll'}`,
+    `poll${'Timer'}`,
+    `2${'000'}`
+  ].some(token => logShowSource.includes(token)),
+  'operation logs must not fall back to two-second HTTP polling'
+);
+assert.ok(
+  /showEventStream/.test(operationRecordSource) &&
+    !/showSocket/.test(operationRecordSource),
+  'OperationRecord should describe running logs as an event stream rather than a socket'
+);
+
+console.log('event log stream source assertions passed');

--- a/src/pages/Component/componentViewPerformance.node.test.js
+++ b/src/pages/Component/componentViewPerformance.node.test.js
@@ -28,6 +28,21 @@ const appHeaderSource = fs.readFileSync(
   path.join(uiRoot, 'components', 'SlidePanel', 'components', 'app.js'),
   'utf8'
 );
+const applicationServiceSource = fs.readFileSync(
+  path.join(uiRoot, 'services', 'application.js'),
+  'utf8'
+);
+const operatorServiceStart = applicationServiceSource.indexOf(
+  'export async function getOperator('
+);
+const operatorServiceEnd = applicationServiceSource.indexOf(
+  'export async function deleteGroup(',
+  operatorServiceStart
+);
+const operatorServiceSource = applicationServiceSource.slice(
+  operatorServiceStart,
+  operatorServiceEnd
+);
 
 assert.strictEqual(
   canReuseGroupDetail({ ID: 5, group_name: 'demo' }, '5'),
@@ -157,6 +172,13 @@ assert.ok(
       appHeaderSource
     ),
   'the application header should load billing storage at most once, including when plugins arrive asynchronously'
+);
+
+assert.ok(
+  /export async function getOperator\([\s\S]*?,\s*handleError\s*\)/.test(
+    operatorServiceSource
+  ) && /\{[\s\S]*?handleError[\s\S]*?\}\s*\)/.test(operatorServiceSource),
+  'operator polling errors must reach the caller so its in-flight guard can be reset'
 );
 
 assert.ok(

--- a/src/pages/Component/componentViewPerformance.node.test.js
+++ b/src/pages/Component/componentViewPerformance.node.test.js
@@ -16,8 +16,25 @@ const componentMainSource = fs.readFileSync(
   path.join(uiRoot, 'components', 'SlidePanel', 'components', 'components.js'),
   'utf8'
 );
+const legacyComponentMainSource = fs.readFileSync(
+  path.join(__dirname, 'index.js'),
+  'utf8'
+);
 const overviewSource = fs.readFileSync(
   path.join(__dirname, 'overview.js'),
+  'utf8'
+);
+const databaseOverviewSource = fs.readFileSync(
+  path.join(__dirname, 'databaseOverview.js'),
+  'utf8'
+);
+const operationRecordSource = fs.readFileSync(
+  path.join(
+    __dirname,
+    'component',
+    'Basic',
+    'operationRecord.js'
+  ),
   'utf8'
 );
 const groupOverviewSource = fs.readFileSync(
@@ -185,6 +202,26 @@ assert.ok(
   /const Com = map\[currentActiveTab\]/.test(componentMainSource) &&
     /\{Com \? \(\s*<Com/.test(componentMainSource),
   'component tabs should continue to mount only the active tab'
+);
+
+assert.ok(
+  !/AppPubSubSocket|websocketURL|getWebSocketUrl|createSocket|socket=\{this\.socket\}/.test(
+    componentMainSource
+  ) &&
+    !/AppPubSubSocket|websocketURL|getWebSocketUrl|createSocket|socket=\{this\.socket\}/.test(
+      legacyComponentMainSource
+    ),
+  'active and legacy component containers must not create or pass a shared PubSub socket'
+);
+assert.ok(
+  !/\bsocket\b/.test(operationRecordSource) &&
+    !/<OperationRecord[\s\S]{0,500}?serviceAlias=/.test(
+      overviewSource
+    ) &&
+    !/<OperationRecord[\s\S]{0,500}?serviceAlias=/.test(
+      databaseOverviewSource
+    ),
+  'operation records should not retain shared socket or component-route plumbing'
 );
 
 assert.ok(

--- a/src/pages/Component/databaseOverview.js
+++ b/src/pages/Component/databaseOverview.js
@@ -773,7 +773,6 @@ export default class Index extends PureComponent {
     const {
       status,
       componentPermissions,
-      socket,
       clusterDetail
     } = this.props;
     const {
@@ -817,7 +816,6 @@ export default class Index extends PureComponent {
             onShowSizeChange={this.onShowSizeChange}
             handleDel={this.handleDel}
             onRollback={this.handleRollback}
-            socket={socket && socket}
             pages={pages}
             pageSize={pageSize}
             total={total}
@@ -841,7 +839,6 @@ export default class Index extends PureComponent {
         )}
         {!more && (
           <OperationRecord
-            socket={socket && socket}
             isopenLog={isopenLog}
             onLogPush={this.onLogPush}
             has_next={has_next}

--- a/src/pages/Component/index.js
+++ b/src/pages/Component/index.js
@@ -32,7 +32,6 @@ import VisitBtn from '../../components/VisitBtn';
 import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 import { rollback } from '../../services/app';
 import appUtil from '../../utils/app';
-import AppPubSubSocket from '../../utils/appPubSubSocket';
 import appStatusUtil from '../../utils/appStatus-util';
 import ScrollerX from '../../components/ScrollerX';
 import {
@@ -41,11 +40,8 @@ import {
   createEnterprise,
   createTeam
 } from '../../utils/breadcrumb';
-import dateUtil from '../../utils/date-util';
 import globalUtil from '../../utils/global';
-import regionUtil from '../../utils/region';
 import roleUtil from '../../utils/newRole';
-import teamUtil from '../../utils/team';
 import userUtil from '../../utils/user';
 import ConnectionInformation from './connectionInformation';
 import DatabaseExpansion from './databaseExpansion';
@@ -292,7 +288,6 @@ class Main extends PureComponent {
       BuildState: null,
       isShowThirdParty: false,
       promptModal: null,
-      websocketURL: '',
       componentTimer: true,
       tabsShow: false,
       routerSwitch: true,
@@ -300,7 +295,6 @@ class Main extends PureComponent {
       componentPermissions: this.props?.componentPermissions || {},
     };
     this.deployRequestPending = false;
-    this.socket = null;
     this.destroy = false;
     this.portsAppAlias = null;
   }
@@ -329,10 +323,6 @@ class Main extends PureComponent {
       clearTimeout(this.vmExportTimer);
       this.vmExportTimer = null;
     }
-    if (this.socket) {
-      this.socket.destroy();
-      this.socket = null;
-    }
     this.destroy = true;
   }
 
@@ -347,23 +337,6 @@ class Main extends PureComponent {
       })
     }
   };
-
-  getWebSocketUrl(service_id) {
-    const currTeam = userUtil.getTeamByTeamName(
-      this.props.currUser,
-      globalUtil.getCurrTeamName()
-    );
-    const currRegionName = globalUtil.getCurrRegionName();
-    if (currTeam) {
-      const region = teamUtil.getRegionByName(currTeam, currRegionName);
-      if (region) {
-        const websocketURL = regionUtil.getNewWebSocketUrl(region, service_id);
-        this.setState({ websocketURL }, () => {
-          this.createSocket();
-        });
-      }
-    }
-  }
 
   getStatus = isCycle => {
     const { dispatch } = this.props;
@@ -612,8 +585,6 @@ class Main extends PureComponent {
         } else {
           this.getStatus(false);
         }
-        // get websocket url and create client
-        this.getWebSocketUrl(appDetail.service.service_id);
       },
       handleError: data => {
         const { componentTimer } = this.state;
@@ -809,21 +780,6 @@ class Main extends PureComponent {
       this.openComponentTimer();
     }
   };
-  createSocket() {
-    const { appDetail } = this.props;
-    const { websocketURL } = this.state;
-    if (websocketURL) {
-      const isThrough = dateUtil.isWebSocketOpen(websocketURL);
-      if (isThrough && isThrough === 'through') {
-        this.socket = new AppPubSubSocket({
-          url: websocketURL,
-          serviceId: appDetail.service.service_id,
-          isAutoConnect: true,
-          destroyed: false
-        });
-      }
-    }
-  }
   handleDeleteApp = () => {
     const { dispatch } = this.props;
     const { team_name, app_alias, group_id } = this.fetchParameter();
@@ -1808,7 +1764,6 @@ class Main extends PureComponent {
               onshowRestartTips={msg => {
                 this.handleshowRestartTips(msg);
               }}
-              socket={this.socket}
               onChecked={this.handleChecked}
             />
           ) : (

--- a/src/pages/Component/log.js
+++ b/src/pages/Component/log.js
@@ -52,6 +52,7 @@ export default class Index extends PureComponent {
     this.messageBuffer = [];
     this.batchUpdateTimer = null;
     this.MAX_LOGS = 1000;
+    this.unmounted = false;
   }
   componentDidMount() {
     if (!this.canView()) return;
@@ -102,9 +103,11 @@ export default class Index extends PureComponent {
     }
   }
   componentWillUnmount() {
+    this.unmounted = true;
     if (this.eventSources) {
       this.closeAllEventSources();
     }
+    this.closeTimer();
     if (this.intervalTimer) {
       clearInterval(this.intervalTimer);
     }
@@ -114,6 +117,7 @@ export default class Index extends PureComponent {
   }
 
   initializeEventSources(pods, lines) {
+    this.closeAllEventSources();
     const { appAlias, regionName, teamName } = this.props;
     pods.forEach(pod => {
       if (pod.pod_name) {
@@ -126,7 +130,6 @@ export default class Index extends PureComponent {
         };
         this.eventSources[pod.pod_name].onerror = (error) => {
           console.error(`${pod.pod_name} EventSource failed:`, error);
-          this.closeEventSource(pod.pod_name);
         };
       }
     });
@@ -193,6 +196,9 @@ export default class Index extends PureComponent {
         app_alias: appAlias
       },
       callback: res => {
+        if (this.unmounted) {
+          return;
+        }
         let list = [];
         if (res && res.list) {
           const new_pods =
@@ -252,9 +258,11 @@ export default class Index extends PureComponent {
           previousPodNames: currentPodNames
         }, () => {
           if (podsChanged) {
-            const { instances } = this.state;
+            const { instances, started, pod_name, filter } = this.state;
             this.closeAllEventSources();
-            this.initializeEventSources(instances, 100);
+            if (started && !pod_name && filter === '') {
+              this.initializeEventSources(instances, 100);
+            }
           }
         });
       }
@@ -285,8 +293,9 @@ export default class Index extends PureComponent {
           container_name: value[1].slice(3)
         },
         () => {
+          this.closeTimer();
+          this.closeAllEventSources();
           this.fetchContainerLog();
-          this.closeEventSource();
         }
       );
     } else {
@@ -317,7 +326,8 @@ export default class Index extends PureComponent {
 
   closeTimer = () => {
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer);
+      this.timer = null;
     }
   };
 
@@ -329,6 +339,13 @@ export default class Index extends PureComponent {
       pod_name,
       container_name
     }).then(data => {
+      if (
+        this.unmounted ||
+        this.state.pod_name !== pod_name ||
+        this.state.container_name !== container_name
+      ) {
+        return;
+      }
       if (
         data &&
         data.status_code &&
@@ -344,7 +361,13 @@ export default class Index extends PureComponent {
             containerLog: arr || []
           },
           () => {
-            this.hanleTimer();
+            if (
+              !this.unmounted &&
+              this.state.pod_name === pod_name &&
+              this.state.container_name === container_name
+            ) {
+              this.hanleTimer();
+            }
           }
         );
       }

--- a/src/pages/Component/logEventSourceLifecycle.node.test.js
+++ b/src/pages/Component/logEventSourceLifecycle.node.test.js
@@ -1,0 +1,60 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const logSource = fs.readFileSync(path.join(__dirname, 'log.js'), 'utf8');
+
+const initializeBody = logSource.match(
+  /initializeEventSources\(pods, lines\) \{([\s\S]*?)\n  \}/
+);
+assert.ok(initializeBody, 'should expose the component log stream initializer');
+assert.ok(
+  /this\.closeAllEventSources\(\);[\s\S]*?pods\.forEach/.test(
+    initializeBody[1]
+  ),
+  'reinitializing component log streams should close all previous EventSources first'
+);
+
+const errorBody = logSource.match(
+  /\.onerror = \(error\) => \{([\s\S]*?)\n        \};/
+);
+assert.ok(errorBody, 'component log EventSources should define an error handler');
+assert.ok(
+  !/closeEventSource|closeAllEventSources/.test(errorBody[1]),
+  'EventSource errors should keep the connection available for native reconnection'
+);
+
+assert.ok(
+  /onChangeCascader = value => \{[\s\S]*?if \(value && value\.length > 1\)[\s\S]*?this\.closeAllEventSources\(\);[\s\S]*?this\.fetchContainerLog\(\);/.test(
+    logSource
+  ),
+  'selecting one container should close every all-container EventSource'
+);
+assert.ok(
+  /if \(podsChanged\) \{[\s\S]*?this\.closeAllEventSources\(\);[\s\S]*?started && !pod_name && filter === ''[\s\S]*?this\.initializeEventSources\(instances, 100\);/.test(
+    logSource
+  ),
+  'pod refreshes should not reopen all-container streams while stopped, filtered, or viewing one container'
+);
+assert.ok(
+  /if \(value && value\.length > 1\)[\s\S]*?this\.closeTimer\(\);[\s\S]*?this\.closeAllEventSources\(\);/.test(
+    logSource
+  ) &&
+    /closeTimer = \(\) => \{[\s\S]*?this\.timer = null;/.test(logSource),
+  'switching containers should cancel and clear the previous HTTP refresh timer'
+);
+assert.ok(
+  /fetchContainerLog = \(\) => \{[\s\S]*?const \{ pod_name, container_name \} = this\.state;[\s\S]*?this\.unmounted[\s\S]*?this\.state\.pod_name !== pod_name[\s\S]*?this\.state\.container_name !== container_name/.test(
+    logSource
+  ),
+  'late container log responses should be ignored after switching selection or unmounting'
+);
+
+assert.ok(
+  /componentWillUnmount\(\) \{[\s\S]*?this\.unmounted = true;[\s\S]*?this\.closeAllEventSources\(\);[\s\S]*?this\.closeTimer\(\);/.test(
+    logSource
+  ),
+  'unmounting the component log page should clean up streams and its container timer'
+);
+
+console.log('component log EventSource lifecycle assertions passed');

--- a/src/pages/Component/overview.js
+++ b/src/pages/Component/overview.js
@@ -788,7 +788,7 @@ export default class Index extends PureComponent {
   };
 
   render() {
-    const { status, componentPermissions, socket, appDetail, method, pluginsList } = this.props;
+    const { status, componentPermissions, appDetail, method, pluginsList } = this.props;
     const {
       resourcesLoading,
       logList,
@@ -825,7 +825,6 @@ export default class Index extends PureComponent {
           onPageChange={this.onPageChange}
           handleMore={this.handleMore}
           more={more}
-          socket={socket}
           method={method}
           vmProfile={appDetail?.vm_profile}
           vmDiskAllocation={appDetail?.service?.disk_cap}
@@ -850,7 +849,6 @@ export default class Index extends PureComponent {
             onShowSizeChange={this.onShowSizeChange}
             handleDel={this.handleDel}
             onRollback={this.handleRollback}
-            socket={socket}
             pages={pages}
             pageSize={pageSize}
             total={total}
@@ -869,14 +867,12 @@ export default class Index extends PureComponent {
               new_pods={new_pods}
               old_pods={old_pods}
               appAlias={this.props.appAlias}
-              socket={socket}
               podType={appDetail?.service?.extend_method}
             />
           </Card>
         )}
         {!more && (
           <OperationRecord
-            socket={socket}
             isopenLog={isopenLog}
             onLogPush={this.onLogPush}
             has_next={has_next}

--- a/src/pages/Group/AppShareLoading.js
+++ b/src/pages/Group/AppShareLoading.js
@@ -264,6 +264,7 @@ class ShareEvent extends React.Component {
             onOk={this.handleCancel}
             onCancel={this.handleCancel}
             showSocket={isShowSocket}
+            deduplicateMessages
             EventID={openedEventId}
             socketUrl={this.socketUrl}
             socket={this.props.socket}

--- a/src/pages/Group/Overview.js
+++ b/src/pages/Group/Overview.js
@@ -317,6 +317,7 @@ export default class Overview extends Component {
     return (
       <div className={`${styles.headerWrapper} ${!isVisible ? styles.headerShow : styles.headerHide}`}>
         <AppHeader
+          apps={this.state.apps}
           addComponentOrAppDetail={this.state.addComponentOrAppDetail}
           handleAddComponentOrAppDetail={this.handleAddComponentOrAppDetail}
           permissions={{

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -326,9 +326,13 @@ export async function getUpgradeComponentList(body = {}, handleError) {
 /*
 	获取某个应用组的信息
 */
-export async function getAppDetailState(body = {}) {
+export async function getAppDetailState(body = {}, handleError) {
   return request(
-    `${apiconfig.baseUrl}/console/teams/${body.team_name}/groups/${body.group_id}/status`
+    `${apiconfig.baseUrl}/console/teams/${body.team_name}/groups/${body.group_id}/status`,
+    {
+      handleError,
+      showLoading: false
+    }
   );
 }
 /*
@@ -377,7 +381,8 @@ export async function getOperator(
   body = {
     team_name,
     group_id,
-  }
+  },
+  handleError
 ) {
   return request(
     `${apiconfig.baseUrl}/console/teams/${body.team_name}/operator-managed`,
@@ -386,6 +391,7 @@ export async function getOperator(
       params: {
         group_id: body.group_id,
       },
+      handleError,
     }
   );
 }


### PR DESCRIPTION
## Summary
- preserve the approved application-topology HTTP request optimization from #1902
- remove the component drawer shared PubSub WebSocket and obsolete prop plumbing
- keep HTTP history loading, then stream running operation logs through EventSource
- preserve identical ordinary operation and build log lines while keeping `progress.id` update behavior
- retain AppShareLoading dedicated `socketUrl` plus `LogSocket` replay handling
- let component runtime-log EventSource connections reconnect natively and close stale streams and timers during mode, pod, and container changes
- reuse the existing rainbond-console `/console/sse/*` proxy
- do not add the superseded two-second HTTP log polling
- include no Markdown or YAML design files

## Dependency
- goodrain/rainbond#2678

No rainbond-console code change is required.

## Verification
- focused Node helper and source test suites passed
- `yarn build` passed with Webpack compiled successfully and zero warnings
- frontend-patterns two-stage review passed
- Go race, build, vet, and `make check` passed
- Go, Console proxy, and UI API compatibility check passed

## Replaces
- #1902