### PR TITLE
fix: reconcile replayed event logs

### DIFF
--- a/src/pages/Component/component/LogShow/eventLogStreamHelpers.js
+++ b/src/pages/Component/component/LogShow/eventLogStreamHelpers.js
@@ -17,6 +17,57 @@ function getEventLogTerminalState(message) {
   return null;
 }
 
+function getEventLogReplayTime(message) {
+  const rawTime =
+    message && message.time !== undefined && message.time !== null
+      ? String(message.time)
+      : '';
+  const isoLikeTime = rawTime
+    .trim()
+    .match(
+      /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?$/i
+    );
+  if (isoLikeTime) {
+    return `wall:${isoLikeTime[1]}T${isoLikeTime[2]}`;
+  }
+  return `raw:${rawTime}`;
+}
+
+function getEventLogReplayKey(message) {
+  const text =
+    message && message.message !== undefined && message.message !== null
+      ? String(message.message)
+      : '';
+  return JSON.stringify([text, getEventLogReplayTime(message)]);
+}
+
+function buildEventLogReplayBudget(logs) {
+  const replayBudget = new Map();
+  const recentLogs = Array.isArray(logs) ? logs.slice(-1000) : [];
+  recentLogs.forEach(message => {
+    const key = getEventLogReplayKey(message);
+    replayBudget.set(key, (replayBudget.get(key) || 0) + 1);
+  });
+  return replayBudget;
+}
+
+function shouldAppendEventStreamMessage(message, replayBudget) {
+  if (!replayBudget) {
+    return true;
+  }
+  const key = getEventLogReplayKey(message);
+  const remaining = replayBudget.get(key) || 0;
+  if (remaining === 0) {
+    return true;
+  }
+  if (remaining === 1) {
+    replayBudget.delete(key);
+  } else {
+    replayBudget.set(key, remaining - 1);
+  }
+  return false;
+}
+
 function shouldAppendEventLog(message, seenMessages, deduplicateMessages) {
   if (!deduplicateMessages) {
     return true;
@@ -29,7 +80,10 @@ function shouldAppendEventLog(message, seenMessages, deduplicateMessages) {
 }
 
 module.exports = {
+  buildEventLogReplayBudget,
   buildEventLogStreamUrl,
   getEventLogTerminalState,
+  getEventLogReplayKey,
+  shouldAppendEventStreamMessage,
   shouldAppendEventLog
 };

--- a/src/pages/Component/component/LogShow/eventLogStreamHelpers.node.test.js
+++ b/src/pages/Component/component/LogShow/eventLogStreamHelpers.node.test.js
@@ -1,7 +1,10 @@
 const assert = require('assert');
 const {
+  buildEventLogReplayBudget,
   buildEventLogStreamUrl,
   getEventLogTerminalState,
+  getEventLogReplayKey,
+  shouldAppendEventStreamMessage,
   shouldAppendEventLog
 } = require('./eventLogStreamHelpers');
 
@@ -55,6 +58,114 @@ assert.strictEqual(
   shouldAppendEventLog(repeatedMessage, appShareMessages, true),
   false,
   'the dedicated app-share socket should retain its existing replay deduplication'
+);
+
+const eventTime = '2026-05-06T17:53:45+08:00';
+const httpHistoryRecord = {
+  message: repeatedMessage,
+  time: '2026-05-06T17:53:45Z',
+  utime: 1
+};
+const sseReplayRecord = {
+  event_id: 'event-1',
+  step: 'build-executor',
+  status: 'running',
+  message: repeatedMessage,
+  level: 'info',
+  time: eventTime
+};
+assert.strictEqual(
+  getEventLogReplayKey(httpHistoryRecord),
+  getEventLogReplayKey(sseReplayRecord),
+  'HTTP history and SSE replay should match by message and wall-clock second without applying timezone offsets'
+);
+assert.strictEqual(
+  getEventLogReplayKey({ ...sseReplayRecord, step: 'another-step' }),
+  getEventLogReplayKey(sseReplayRecord),
+  'SSE-only fields must not participate in the cross-transport replay key'
+);
+assert.strictEqual(
+  getEventLogReplayKey({
+    message: repeatedMessage,
+    time: '2026-05-06 17:53:45.987'
+  }),
+  getEventLogReplayKey({
+    message: repeatedMessage,
+    time: '2026-05-06T17:53:45+0800'
+  }),
+  'ISO-like times should normalize T or space separators and ignore milliseconds and timezone suffixes'
+);
+assert.notStrictEqual(
+  getEventLogReplayKey({
+    message: repeatedMessage,
+    time: 'not-a-date',
+    utime: 1778061225
+  }),
+  getEventLogReplayKey(sseReplayRecord),
+  'HTTP-only utime must not override the shared time field'
+);
+
+assert.strictEqual(
+  getEventLogReplayKey({ message: 'fallback', time: 'not-a-date' }),
+  getEventLogReplayKey({
+    message: 'fallback',
+    time: 'not-a-date',
+    utime: 0
+  }),
+  'unparseable times should fall back to the original time instead of the backend zero sentinel'
+);
+assert.notStrictEqual(
+  getEventLogReplayKey({ message: 'fallback', time: 'not-a-date' }),
+  getEventLogReplayKey({ message: 'fallback', time: 'another-invalid-date' }),
+  'different raw times should stay distinguishable when parsing fails'
+);
+
+const repeatedHistory = [
+  { message: repeatedMessage, time: '2026-05-06T17:53:45Z', utime: 1 },
+  { message: repeatedMessage, time: '2026-05-06 17:53:45.999' }
+];
+const replayBudget = buildEventLogReplayBudget(repeatedHistory);
+assert.strictEqual(
+  shouldAppendEventStreamMessage(sseReplayRecord, replayBudget),
+  false,
+  'the first replay copy should consume one matching HTTP history copy'
+);
+assert.strictEqual(
+  shouldAppendEventStreamMessage(sseReplayRecord, replayBudget),
+  false,
+  'the second replay copy should consume the second matching HTTP history copy'
+);
+assert.strictEqual(
+  shouldAppendEventStreamMessage(sseReplayRecord, replayBudget),
+  true,
+  'a third replay copy should remain visible when HTTP history contained only two copies'
+);
+assert.strictEqual(
+  shouldAppendEventStreamMessage(sseReplayRecord, null),
+  true,
+  'after replay-complete the same legitimate live line should always be appended'
+);
+
+const moreThanReplayLimit = Array.from({ length: 1001 }, (_, index) => ({
+  message: `line-${index}`,
+  time: eventTime
+}));
+const limitedBudget = buildEventLogReplayBudget(moreThanReplayLimit);
+assert.strictEqual(
+  shouldAppendEventStreamMessage(
+    { message: 'line-0', time: eventTime },
+    limitedBudget
+  ),
+  true,
+  'reconnect reconciliation should ignore UI lines older than the server 1000-line replay window'
+);
+assert.strictEqual(
+  shouldAppendEventStreamMessage(
+    { message: 'line-1', time: eventTime },
+    limitedBudget
+  ),
+  false,
+  'reconnect reconciliation should include the oldest line inside the server replay window'
 );
 
 console.log('event log stream helper tests passed');

--- a/src/pages/Component/component/LogShow/index.js
+++ b/src/pages/Component/component/LogShow/index.js
@@ -7,8 +7,10 @@ import dateUtil from '../../../../utils/date-util';
 import globalUtil from '../../../../utils/global';
 import LogSocket from '../../../../utils/logSocket';
 import {
+  buildEventLogReplayBudget,
   buildEventLogStreamUrl,
   getEventLogTerminalState,
+  shouldAppendEventStreamMessage,
   shouldAppendEventLog
 } from './eventLogStreamHelpers';
 import styles from './index.less';
@@ -33,6 +35,7 @@ class Index extends React.Component {
     this.state.dockerprogress = new Map();
     // 仅供需要保留历史行为的独立 WebSocket 日志去重
     this.seenMessages = new Set();
+    this.eventLogReplayBudget = null;
     this.eventSource = null;
     this.socket = null;
     this.unmounted = false;
@@ -174,15 +177,35 @@ class Index extends React.Component {
     const regionName = globalUtil.getCurrRegionName();
     const url = buildEventLogStreamUrl(EventID, regionName);
     this.closeEventSource();
-    this.eventSource = new EventSource(url, { withCredentials: true });
-    this.eventSource.onmessage = event => {
+    const eventSource = new EventSource(url, { withCredentials: true });
+    this.eventSource = eventSource;
+    eventSource.onopen = () => {
+      if (this.eventSource !== eventSource) {
+        return;
+      }
+      this.eventLogReplayBudget = buildEventLogReplayBudget(this.state.logs);
+    };
+    eventSource.addEventListener('replay-complete', () => {
+      if (this.eventSource !== eventSource) {
+        return;
+      }
+      this.eventLogReplayBudget = null;
+    });
+    eventSource.onmessage = event => {
+      if (this.eventSource !== eventSource) {
+        return;
+      }
       let message;
       try {
         message = JSON.parse(event.data);
       } catch (err) {
         return;
       }
-      this.handleMessage(message);
+      if (
+        shouldAppendEventStreamMessage(message, this.eventLogReplayBudget)
+      ) {
+        this.handleMessage(message);
+      }
       const terminalState = getEventLogTerminalState(message);
       if (terminalState) {
         this.setState({
@@ -198,6 +221,7 @@ class Index extends React.Component {
     };
   };
   closeEventSource = () => {
+    this.eventLogReplayBudget = null;
     if (this.eventSource) {
       this.eventSource.close();
       this.eventSource = null;

--- a/src/pages/Component/component/LogShow/index.node.test.js
+++ b/src/pages/Component/component/LogShow/index.node.test.js
@@ -40,6 +40,42 @@ assert.ok(
   'SSE data frames should be parsed and checked for terminal messages'
 );
 assert.ok(
+  /const eventSource = new EventSource\(url,[\s\S]*?this\.eventSource = eventSource/.test(
+    logShowSource
+  ),
+  'event stream callbacks should capture the EventSource instance they belong to'
+);
+assert.ok(
+  /eventSource\.onopen\s*=\s*\(\)\s*=>\s*\{\s*if \(this\.eventSource !== eventSource\) \{\s*return;\s*\}[\s\S]*?buildEventLogReplayBudget\(this\.state\.logs\)/.test(
+    logShowSource
+  ),
+  'only the current EventSource should rebuild replay counts on connection and native reconnect'
+);
+assert.ok(
+  /eventSource\.addEventListener\(\s*['"]replay-complete['"],\s*\(\)\s*=>\s*\{\s*if \(this\.eventSource !== eventSource\) \{\s*return;\s*\}[\s\S]*?this\.eventLogReplayBudget\s*=\s*null/.test(
+    logShowSource
+  ),
+  'only the current EventSource replay-complete boundary should end overlap reconciliation'
+);
+assert.ok(
+  /eventSource\.onmessage\s*=\s*event\s*=>\s*\{\s*if \(this\.eventSource !== eventSource\) \{\s*return;\s*\}/.test(
+    logShowSource
+  ),
+  'queued messages from a replaced EventSource must not update logs or terminal state'
+);
+assert.ok(
+  /shouldAppendEventStreamMessage\(message,\s*this\.eventLogReplayBudget\)[\s\S]*?this\.handleMessage\(message\)/.test(
+    logShowSource
+  ),
+  'only replay messages unmatched by the HTTP history multiset should be rendered'
+);
+assert.ok(
+  /const terminalState = getEventLogTerminalState\(message\)[\s\S]*?if \(terminalState\)[\s\S]*?this\.closeEventSource\(\)/.test(
+    logShowSource
+  ),
+  'terminal state handling must remain independent from replay rendering suppression'
+);
+assert.ok(
   /closeEventSource\s*=/.test(logShowSource) &&
     /componentWillUnmount\(\)[\s\S]*?this\.closeEventSource\(\)/.test(
       logShowSource


### PR DESCRIPTION
## Summary

- reconcile HTTP event history with SSE replay using a count-aware message and timestamp key
- stop reconciliation at the replay-complete boundary so identical live logs remain visible
- rebuild the replay budget on EventSource reconnect and isolate callbacks from stale connections
- keep BuildHistory, component runtime logs, AppShare WebSocket, and PubSub paths unchanged

## Dependency

Requires goodrain/rainbond#2679, which adds the replay-complete SSE boundary.

## Validation

- five targeted Node regression tests
- production yarn build (0 warnings)
- frontend pattern and cross-repository API reviews
- git diff --check

No Markdown or YAML design files are included. Console remains unchanged.