### PR TITLE
fix: reconcile replayed component logs

### DIFF
--- a/src/pages/Component/log.js
+++ b/src/pages/Component/log.js
@@ -8,6 +8,11 @@ import { getContainerLog, getServiceLog } from '../../services/app';
 import appUtil from '../../utils/app';
 import globalUtil from '../../utils/global';
 import HistoryLog from './component/Log/history';
+import {
+  buildRuntimeLogReplayBudget,
+  rememberRuntimeLogMessage,
+  shouldAppendRuntimeLogMessage
+} from './runtimeLogReplayHelpers';
 import apiconfig from '../../../config/api.config';
 import styles from './Log.less';
 import { FormattedMessage } from 'umi';
@@ -49,6 +54,8 @@ export default class Index extends PureComponent {
       previousPodNames: []
     };
     this.eventSources = {};
+    this.runtimeLogReplayBudgets = {};
+    this.recentRuntimeLogMessages = [];
     this.messageBuffer = [];
     this.batchUpdateTimer = null;
     this.MAX_LOGS = 1000;
@@ -121,25 +128,62 @@ export default class Index extends PureComponent {
     const { appAlias, regionName, teamName } = this.props;
     pods.forEach(pod => {
       if (pod.pod_name) {
-        const url = `/console/sse/v2/tenants/${teamName}/services/${appAlias}/pods/${pod.pod_name}/logs?region_name=${regionName}&lines=${lines}`;
-        this.eventSources[pod.pod_name] = new EventSource(url, { withCredentials: true });
-        this.eventSources[pod.pod_name].onmessage = (event) => {
+        const podName = pod.pod_name;
+        const url = `/console/sse/v2/tenants/${teamName}/services/${appAlias}/pods/${podName}/logs?region_name=${regionName}&lines=${lines}`;
+        const eventSource = new EventSource(url, { withCredentials: true });
+        this.eventSources[podName] = eventSource;
+        eventSource.onopen = () => {
+          if (this.eventSources[podName] !== eventSource) {
+            return;
+          }
+          this.runtimeLogReplayBudgets[podName] = buildRuntimeLogReplayBudget(
+            this.recentRuntimeLogMessages,
+            podName,
+            lines
+          );
+        };
+        eventSource.onmessage = event => {
+          if (this.eventSources[podName] !== eventSource) {
+            return;
+          }
           const newMessage = event.data;
+          if (
+            !shouldAppendRuntimeLogMessage(
+              newMessage,
+              this.runtimeLogReplayBudgets[podName]
+            )
+          ) {
+            return;
+          }
+          rememberRuntimeLogMessage(
+            this.recentRuntimeLogMessages,
+            podName,
+            newMessage,
+            this.MAX_LOGS
+          );
           this.messageBuffer.push(newMessage);
           this.debouncedBatchUpdate();
         };
-        this.eventSources[pod.pod_name].onerror = (error) => {
-          console.error(`${pod.pod_name} EventSource failed:`, error);
+        eventSource.onerror = (error) => {
+          if (this.eventSources[podName] !== eventSource) {
+            return;
+          }
+          console.error(`${podName} EventSource failed:`, error);
         };
       }
     });
   }
 
   closeEventSource(podsName) {
-    if (this.eventSources[podsName]) {
-      this.eventSources[podsName].close();
+    const eventSource = this.eventSources[podsName];
+    if (eventSource) {
+      eventSource.onopen = null;
+      eventSource.onmessage = null;
+      eventSource.onerror = null;
+      eventSource.close();
       delete this.eventSources[podsName];
     }
+    delete this.runtimeLogReplayBudgets[podsName];
   }
 
   closeAllEventSources() {
@@ -398,6 +442,10 @@ export default class Index extends PureComponent {
     });
     if (newlogs.length > 5000) {
       newlogs = newlogs.slice(logs.length - 5000, logs.length);
+    }
+    if (!podName) {
+      this.recentRuntimeLogMessages = [];
+      this.runtimeLogReplayBudgets = {};
     }
     const updateInfo = podName ? { containerLog: newlogs } : { logs: newlogs };
     this.setState(updateInfo);

--- a/src/pages/Component/logEventSourceLifecycle.node.test.js
+++ b/src/pages/Component/logEventSourceLifecycle.node.test.js
@@ -14,6 +14,24 @@ assert.ok(
   ),
   'reinitializing component log streams should close all previous EventSources first'
 );
+assert.ok(
+  /const eventSource = new EventSource\([\s\S]*?this\.eventSources\[podName\] = eventSource/.test(
+    initializeBody[1]
+  ),
+  'each pod stream should keep a stable EventSource identity'
+);
+assert.ok(
+  /eventSource\.onopen = \(\) => \{[\s\S]*?this\.eventSources\[podName\] !== eventSource[\s\S]*?buildRuntimeLogReplayBudget\([\s\S]*?podName,[\s\S]*?lines/.test(
+    initializeBody[1]
+  ),
+  'opening or reconnecting a pod stream should rebuild its bounded replay budget'
+);
+assert.ok(
+  /eventSource\.onmessage = event => \{[\s\S]*?this\.eventSources\[podName\] !== eventSource[\s\S]*?shouldAppendRuntimeLogMessage\([\s\S]*?return;[\s\S]*?rememberRuntimeLogMessage\([\s\S]*?this\.messageBuffer\.push/.test(
+    initializeBody[1]
+  ),
+  'only current, non-replayed pod messages should be remembered and rendered'
+);
 
 const errorBody = logSource.match(
   /\.onerror = \(error\) => \{([\s\S]*?)\n        \};/
@@ -55,6 +73,19 @@ assert.ok(
     logSource
   ),
   'unmounting the component log page should clean up streams and its container timer'
+);
+
+assert.ok(
+  /closeEventSource\(podsName\) \{[\s\S]*?eventSource\.onopen = null;[\s\S]*?eventSource\.onmessage = null;[\s\S]*?eventSource\.onerror = null;[\s\S]*?eventSource\.close\(\);[\s\S]*?delete this\.runtimeLogReplayBudgets\[podsName\]/.test(
+    logSource
+  ),
+  'closing a pod stream should detach callbacks and discard only its replay budget'
+);
+assert.ok(
+  /setLogs = logs => \{[\s\S]*?if \(!podName\) \{[\s\S]*?this\.recentRuntimeLogMessages = \[\];[\s\S]*?this\.runtimeLogReplayBudgets = \{\};/.test(
+    logSource
+  ),
+  'filtering the combined view should reset replay history so clearing the filter can restore the server tail'
 );
 
 console.log('component log EventSource lifecycle assertions passed');

--- a/src/pages/Component/runtimeLogReplayHelpers.js
+++ b/src/pages/Component/runtimeLogReplayHelpers.js
@@ -1,0 +1,52 @@
+const {
+  buildEventLogReplayBudget,
+  shouldAppendEventStreamMessage
+} = require('./component/LogShow/eventLogStreamHelpers');
+
+function toReplayMessage(message) {
+  return { message, time: '' };
+}
+
+function buildRuntimeLogReplayBudget(recentMessages, podName, lines) {
+  const tailLines = Number(lines);
+  if (!Number.isFinite(tailLines) || tailLines <= 0) {
+    return buildEventLogReplayBudget([]);
+  }
+  const replayMessages = (Array.isArray(recentMessages) ? recentMessages : [])
+    .filter(item => item && item.podName === podName)
+    .slice(-tailLines)
+    .map(item => toReplayMessage(item.message));
+  return buildEventLogReplayBudget(replayMessages);
+}
+
+function shouldAppendRuntimeLogMessage(message, replayBudget) {
+  return shouldAppendEventStreamMessage(
+    toReplayMessage(message),
+    replayBudget
+  );
+}
+
+function rememberRuntimeLogMessage(
+  recentMessages,
+  podName,
+  message,
+  limit = 1000
+) {
+  if (!Array.isArray(recentMessages)) {
+    return;
+  }
+  recentMessages.push({ podName, message });
+  const historyLimit = Number(limit);
+  if (Number.isFinite(historyLimit) && historyLimit >= 0) {
+    const overflow = recentMessages.length - historyLimit;
+    if (overflow > 0) {
+      recentMessages.splice(0, overflow);
+    }
+  }
+}
+
+module.exports = {
+  buildRuntimeLogReplayBudget,
+  rememberRuntimeLogMessage,
+  shouldAppendRuntimeLogMessage
+};

--- a/src/pages/Component/runtimeLogReplayHelpers.node.test.js
+++ b/src/pages/Component/runtimeLogReplayHelpers.node.test.js
@@ -1,0 +1,89 @@
+const assert = require('assert');
+const {
+  buildRuntimeLogReplayBudget,
+  rememberRuntimeLogMessage,
+  shouldAppendRuntimeLogMessage
+} = require('./runtimeLogReplayHelpers');
+
+const repeatedLine = '2026-08-17T10:00:00.000000000Z repeated output';
+const recentMessages = [
+  { podName: 'pod-a', message: repeatedLine },
+  { podName: 'pod-b', message: repeatedLine },
+  { podName: 'pod-a', message: repeatedLine }
+];
+const replayBudget = buildRuntimeLogReplayBudget(
+  recentMessages,
+  'pod-a',
+  100
+);
+
+assert.strictEqual(
+  shouldAppendRuntimeLogMessage(repeatedLine, replayBudget),
+  false,
+  'the first replay copy should consume one matching line from the same pod'
+);
+assert.strictEqual(
+  shouldAppendRuntimeLogMessage(repeatedLine, replayBudget),
+  false,
+  'the second replay copy should consume the second matching line from the same pod'
+);
+assert.strictEqual(
+  shouldAppendRuntimeLogMessage(repeatedLine, replayBudget),
+  true,
+  'a third identical line should remain visible when only two copies were previously accepted'
+);
+
+const otherPodBudget = buildRuntimeLogReplayBudget(
+  [{ podName: 'pod-b', message: repeatedLine }],
+  'pod-a',
+  100
+);
+assert.strictEqual(
+  shouldAppendRuntimeLogMessage(repeatedLine, otherPodBudget),
+  true,
+  'a matching line from another pod must not suppress this pod output'
+);
+
+const tailBudget = buildRuntimeLogReplayBudget(
+  [
+    { podName: 'pod-a', message: 'old-line' },
+    { podName: 'pod-a', message: 'new-line-1' },
+    { podName: 'pod-a', message: 'new-line-2' }
+  ],
+  'pod-a',
+  2
+);
+assert.strictEqual(
+  shouldAppendRuntimeLogMessage('old-line', tailBudget),
+  true,
+  'lines older than the requested server tail should not enter the replay budget'
+);
+assert.strictEqual(
+  shouldAppendRuntimeLogMessage('new-line-1', tailBudget),
+  false,
+  'the oldest line inside the requested server tail should be reconciled'
+);
+
+const sameContentAtAnotherTime =
+  '2026-08-17T10:00:01.000000000Z repeated output';
+assert.strictEqual(
+  shouldAppendRuntimeLogMessage(sameContentAtAnotherTime, replayBudget),
+  true,
+  'the Kubernetes timestamp keeps a legitimate later line distinct'
+);
+
+const boundedHistory = [];
+['line-1', 'line-2', 'line-3', 'line-4'].forEach(message => {
+  rememberRuntimeLogMessage(boundedHistory, 'pod-a', message, 3);
+});
+assert.deepStrictEqual(
+  boundedHistory,
+  [
+    { podName: 'pod-a', message: 'line-2' },
+    { podName: 'pod-a', message: 'line-3' },
+    { podName: 'pod-a', message: 'line-4' }
+  ],
+  'accepted runtime log history should stay globally bounded'
+);
+
+console.log('runtime log replay helper tests passed');


### PR DESCRIPTION
## Summary
- reconcile the per-pod SSE tail replay when component log streams reconnect
- preserve legitimate repeated messages with count-aware matching and Kubernetes timestamps
- ignore callbacks from stale EventSource instances while keeping native reconnection enabled

## Scope
- UI-only change; no SSE endpoint, Console proxy, or operation-log behavior changes
- no design Markdown or YAML files included

## Verification
- node src/pages/Component/runtimeLogReplayHelpers.node.test.js
- node src/pages/Component/logEventSourceLifecycle.node.test.js
- node src/pages/Component/component/LogShow/eventLogStreamHelpers.node.test.js
- node src/pages/Component/component/LogShow/index.node.test.js
- node src/pages/Component/componentViewPerformance.node.test.js
- yarn build