### PR TITLE
fix: restrict platform resource management access

### DIFF
--- a/src/pages/PlatformResources/index.js
+++ b/src/pages/PlatformResources/index.js
@@ -23,6 +23,8 @@ import pageheaderSvg from '@/utils/pageHeaderSvg';
 import jsYaml from 'js-yaml';
 import styles from './index.less';
 import theme from '../../../config/theme';
+import userUtil from '../../utils/user';
+import Exception from '../Exception/403';
 
 const { TabPane } = Tabs;
 const { Option } = Select;
@@ -147,12 +149,13 @@ const StatusDot = ({ status }) => {
   );
 };
 
-@connect(({ platformResources }) => ({
+@connect(({ platformResources, user }) => ({
   storageClasses: platformResources.storageClasses,
   persistentVolumes: platformResources.persistentVolumes,
   platformResources: platformResources.platformResources,
   resourceInstances: platformResources.resourceInstances,
   storageConfig: platformResources.storageConfig,
+  currentUser: user.currentUser,
 }))
 class PlatformResources extends PureComponent {
   state = {
@@ -187,11 +190,19 @@ class PlatformResources extends PureComponent {
   };
 
   componentDidMount() {
+    if (!this.canAccessPlatformResources()) {
+      return;
+    }
     this.fetchStorageClasses();
     this.fetchPersistentVolumes();
     this.fetchStorageConfig();
     this.fetchPlatformResources();
   }
+
+  canAccessPlatformResources = () => {
+    const { currentUser } = this.props;
+    return userUtil.isCompanyAdmin(currentUser);
+  };
 
   componentDidUpdate(prevProps, prevState) {
     const resourcesChanged = prevProps.platformResources !== this.props.platformResources;
@@ -1344,6 +1355,10 @@ class PlatformResources extends PureComponent {
   }
 
   render() {
+    if (!this.canAccessPlatformResources()) {
+      return <Exception />;
+    }
+
     const { createModalVisible, yamlContent, mainTab, storageResourceModal } = this.state;
 
     const storageResourceModalTitle = storageResourceModal.mode === 'edit'

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -75,12 +75,7 @@ const userUtil = {
   },
   // 是否是企业管理员
   isCompanyAdmin(userBean) {
-    return (
-      userBean &&
-      userBean.roles &&
-      userBean.roles.length > 0 &&
-      userBean.roles.includes('admin')
-    );
+    return !!(userBean && userBean.is_enterprise_admin === true);
   },
   // 是否有对应的权限
   isPermissions(userBean, parameter) {

--- a/src/utils/user.node.test.js
+++ b/src/utils/user.node.test.js
@@ -1,0 +1,46 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const userSourcePath = path.join(__dirname, 'user.js');
+const source = fs
+  .readFileSync(userSourcePath, 'utf8')
+  .replace(/^import .*;\n/gm, '')
+  .replace(/export default userUtil;/, 'module.exports = userUtil;');
+const sandbox = {
+  module: { exports: {} },
+  exports: {},
+};
+
+vm.runInNewContext(source, sandbox, { filename: userSourcePath });
+
+const userUtil = sandbox.module.exports;
+
+assert.strictEqual(
+  userUtil.isCompanyAdmin({ is_enterprise_admin: true, roles: ['user'] }),
+  true,
+  'a later-created enterprise administrator should be recognized'
+);
+assert.strictEqual(
+  userUtil.isCompanyAdmin({ is_enterprise_admin: true, roles: ['admin'] }),
+  true,
+  'the initial enterprise administrator should remain recognized'
+);
+assert.strictEqual(
+  userUtil.isCompanyAdmin({ is_enterprise_admin: false, roles: ['user'] }),
+  false,
+  'an ordinary user should not be recognized as an enterprise administrator'
+);
+assert.strictEqual(
+  userUtil.isCompanyAdmin(null),
+  false,
+  'missing user information should not be recognized as an enterprise administrator'
+);
+assert.strictEqual(
+  userUtil.isCompanyAdmin({ roles: ['admin'] }),
+  false,
+  'a legacy admin role alone should not grant enterprise administrator access'
+);
+
+console.log('user administrator checks passed');


### PR DESCRIPTION
## Summary

- use the server-provided enterprise administrator flag for all administrator checks
- recognize platform administrators created after the initial admin account
- hide platform resource initialization behind a page-level authorization guard and render the existing 403 page for direct unauthorized URLs
- add real-source regression coverage for initial admins, later admins, ordinary users, missing users, and legacy-role spoofing

## Verification

- Node administrator regression test: passed
- yarn build: compiled successfully with 0 warnings
- diff check: passed

## Related backend security boundary

- https://github.com/goodrain/rainbond-console/pull/2118