### PR TITLE
feat: improve Maven multi-module configuration

### DIFF
--- a/src/components/AppCreateMoreService/helpers.js
+++ b/src/components/AppCreateMoreService/helpers.js
@@ -1,0 +1,148 @@
+const {
+  mergeRuntimeBuildEnvs
+} = require('../CodeBuildConfig/buildEnvHelpers');
+
+const MODULE_ROLE_RUNNABLE = 'runnable';
+const MODULE_ROLE_POSSIBLE_DEPENDENCY = 'possible_dependency';
+const MAVEN_CANONICAL_LEGACY_ALIASES = {
+  BP_MAVEN_BUILD_ARGUMENTS: 'BUILD_MAVEN_CUSTOM_GOALS',
+  BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS: 'BUILD_MAVEN_CUSTOM_OPTS',
+  BP_MAVEN_BUILT_MODULE: 'BUILD_MAVEN_BUILT_MODULE',
+  BP_MAVEN_BUILT_ARTIFACT: 'BUILD_MAVEN_BUILT_ARTIFACT'
+};
+
+const roleRank = role => {
+  if (role === MODULE_ROLE_RUNNABLE) {
+    return 0;
+  }
+  if (role === MODULE_ROLE_POSSIBLE_DEPENDENCY) {
+    return 2;
+  }
+  return 1;
+};
+
+const cloneModule = module => {
+  if (!module || typeof module !== 'object') {
+    return module;
+  }
+  return {
+    ...module,
+    envs: Array.isArray(module.envs)
+      ? module.envs.map(env =>
+          env && typeof env === 'object' ? { ...env } : env
+        )
+      : module.envs
+  };
+};
+
+const sortModules = (modules = []) =>
+  (Array.isArray(modules) ? modules : [])
+    .map((module, index) => ({ module: cloneModule(module), index }))
+    .sort((left, right) => {
+      const rankDiff =
+        roleRank(left.module && left.module.module_role) -
+        roleRank(right.module && right.module.module_role);
+      return rankDiff || left.index - right.index;
+    })
+    .map(item => item.module);
+
+const getDefaultSelectedKeys = (modules = []) => {
+  const moduleList = Array.isArray(modules) ? modules : [];
+  const runnableModules = moduleList.filter(
+    module => module && module.module_role === MODULE_ROLE_RUNNABLE
+  );
+  const selectedModules = runnableModules.length ? runnableModules : moduleList;
+  return selectedModules.map(module => module && module.id);
+};
+
+const getSelectedModules = (modules = [], selectedKeys = []) => {
+  const keyList = Array.isArray(selectedKeys) ? selectedKeys : [];
+  return (Array.isArray(modules) ? modules : []).filter(
+    module => module && keyList.indexOf(module.id) !== -1
+  );
+};
+
+const hasSameModuleIds = (previousModules = [], nextModules = []) => {
+  const previousIds = (Array.isArray(previousModules) ? previousModules : []).map(
+    module => module && module.id
+  );
+  const unmatchedIds = (Array.isArray(nextModules) ? nextModules : []).map(
+    module => module && module.id
+  );
+  if (previousIds.length !== unmatchedIds.length) {
+    return false;
+  }
+  return previousIds.every(id => {
+    const matchIndex = unmatchedIds.indexOf(id);
+    if (matchIndex === -1) {
+      return false;
+    }
+    unmatchedIds.splice(matchIndex, 1);
+    return true;
+  });
+};
+
+const reconcileSelectedKeys = (
+  previousModules = [],
+  nextModules = [],
+  selectedKeys = []
+) => {
+  if (!hasSameModuleIds(previousModules, nextModules)) {
+    return getDefaultSelectedKeys(nextModules);
+  }
+  const nextIds = nextModules.map(module => module && module.id);
+  return (Array.isArray(selectedKeys) ? selectedKeys : []).filter(
+    key => nextIds.indexOf(key) !== -1
+  );
+};
+
+const envListToMap = (envs = []) =>
+  (Array.isArray(envs) ? envs : []).reduce((envMap, env) => {
+    if (env && env.name) {
+      envMap[env.name] = env.value;
+    }
+    return envMap;
+  }, {});
+
+const envMapToList = (envMap = {}) => {
+  if (!envMap || typeof envMap !== 'object' || Array.isArray(envMap)) {
+    return [];
+  }
+  return Object.keys(envMap).map(name => ({ name, value: envMap[name] }));
+};
+
+const normalizeDetectedModules = (modules = []) =>
+  (Array.isArray(modules) ? modules : []).map((module, index) => ({
+    ...(module || {}),
+    index
+  }));
+
+const mergeModuleBuildEnvs = (existingEnvs = [], fieldsValue = {}) => {
+  const canonicalFields =
+    fieldsValue && typeof fieldsValue === 'object' ? fieldsValue : {};
+  const mergedEnvMap = mergeRuntimeBuildEnvs(
+    envListToMap(existingEnvs),
+    canonicalFields
+  );
+
+  Object.keys(MAVEN_CANONICAL_LEGACY_ALIASES).forEach(canonicalName => {
+    if (Object.prototype.hasOwnProperty.call(canonicalFields, canonicalName)) {
+      delete mergedEnvMap[MAVEN_CANONICAL_LEGACY_ALIASES[canonicalName]];
+    }
+  });
+
+  return envMapToList(mergedEnvMap);
+};
+
+module.exports = {
+  MODULE_ROLE_POSSIBLE_DEPENDENCY,
+  MODULE_ROLE_RUNNABLE,
+  envListToMap,
+  envMapToList,
+  getDefaultSelectedKeys,
+  getSelectedModules,
+  mergeModuleBuildEnvs,
+  normalizeDetectedModules,
+  reconcileSelectedKeys,
+  sortModules
+};

--- a/src/components/AppCreateMoreService/helpers.node.test.js
+++ b/src/components/AppCreateMoreService/helpers.node.test.js
@@ -1,0 +1,281 @@
+const assert = require('assert');
+const {
+  envListToMap,
+  envMapToList,
+  getDefaultSelectedKeys,
+  getSelectedModules,
+  mergeModuleBuildEnvs,
+  normalizeDetectedModules,
+  reconcileSelectedKeys,
+  sortModules
+} = require('./helpers');
+
+const detectedModules = [{ id: 'module-a' }, { id: 'module-b', index: 99 }];
+const normalizedDetectedModules = normalizeDetectedModules(detectedModules);
+
+assert.deepStrictEqual(
+  normalizedDetectedModules,
+  [{ id: 'module-a', index: 0 }, { id: 'module-b', index: 1 }],
+  'should defensively normalize detected modules and assign stable display indexes'
+);
+assert.notStrictEqual(
+  normalizedDetectedModules[0],
+  detectedModules[0],
+  'should clone detected module rows instead of mutating API response objects'
+);
+assert.deepStrictEqual(
+  detectedModules,
+  [{ id: 'module-a' }, { id: 'module-b', index: 99 }],
+  'should leave the API response list untouched'
+);
+assert.deepStrictEqual(
+  normalizeDetectedModules(null),
+  [],
+  'should normalize a missing detected module list to an empty array'
+);
+
+const modules = [
+  { id: 'unknown-a' },
+  { id: 'dep-a', module_role: 'possible_dependency' },
+  { id: 'run-a', module_role: 'runnable' },
+  { id: 'unknown-b', module_role: 'custom' },
+  { id: 'run-b', module_role: 'runnable' },
+  { id: 'dep-b', module_role: 'possible_dependency' }
+];
+
+assert.deepStrictEqual(
+  sortModules(modules).map(item => item.id),
+  ['run-a', 'run-b', 'unknown-a', 'unknown-b', 'dep-a', 'dep-b'],
+  'should stably sort runnable modules first and possible dependencies last'
+);
+
+assert.deepStrictEqual(
+  modules.map(item => item.id),
+  ['unknown-a', 'dep-a', 'run-a', 'unknown-b', 'run-b', 'dep-b'],
+  'should not mutate the detected module list while sorting'
+);
+
+const modulesWithEnvs = [
+  {
+    id: 'module-with-envs',
+    module_role: 'runnable',
+    envs: [{ name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' }]
+  }
+];
+const normalizedModules = sortModules(modulesWithEnvs);
+
+assert.notStrictEqual(
+  normalizedModules[0],
+  modulesWithEnvs[0],
+  'should clone module objects while normalizing detected data'
+);
+assert.notStrictEqual(
+  normalizedModules[0].envs,
+  modulesWithEnvs[0].envs,
+  'should clone module env arrays while normalizing detected data'
+);
+assert.notStrictEqual(
+  normalizedModules[0].envs[0],
+  modulesWithEnvs[0].envs[0],
+  'should clone module env entries while normalizing detected data'
+);
+normalizedModules[0].envs[0].value = 'changed';
+assert.strictEqual(
+  modulesWithEnvs[0].envs[0].value,
+  'service-a',
+  'should keep source module env values untouched after editing normalized data'
+);
+
+assert.deepStrictEqual(
+  getDefaultSelectedKeys(modules),
+  ['run-a', 'run-b'],
+  'should default-select only runnable modules when any are detected'
+);
+
+const modulesWithoutRunnable = [
+  { id: 'unknown', module_role: 'custom' },
+  { id: 'dep', module_role: 'possible_dependency' }
+];
+
+assert.deepStrictEqual(
+  getDefaultSelectedKeys(modulesWithoutRunnable),
+  ['unknown', 'dep'],
+  'should select every module when no runnable module is detected'
+);
+
+assert.deepStrictEqual(
+  getDefaultSelectedKeys([]),
+  [],
+  'should handle an empty module list'
+);
+
+assert.deepStrictEqual(
+  getSelectedModules(modules, ['run-b', 'unknown-a']),
+  [modules[0], modules[4]],
+  'should derive selected modules in the current display order'
+);
+
+assert.deepStrictEqual(
+  reconcileSelectedKeys(
+    [{ id: 'module-a' }, { id: 'module-b' }],
+    [{ id: 'module-b' }, { id: 'module-a' }],
+    ['module-a', 'missing']
+  ),
+  ['module-a'],
+  'should preserve and crop controlled selection when the dataset is unchanged'
+);
+
+assert.deepStrictEqual(
+  reconcileSelectedKeys(
+    [{ id: 'old-module' }],
+    [
+      { id: 'new-dependency', module_role: 'possible_dependency' },
+      { id: 'new-runnable', module_role: 'runnable' }
+    ],
+    ['old-module']
+  ),
+  ['new-runnable'],
+  'should apply runnable defaults when a genuinely new dataset arrives'
+);
+
+assert.deepStrictEqual(
+  envListToMap([
+    { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' },
+    { name: 'CUSTOM_RUNTIME', value: 'keep' }
+  ]),
+  {
+    BUILD_MAVEN_BUILT_MODULE: 'service-a',
+    CUSTOM_RUNTIME: 'keep'
+  },
+  'should convert an environment variable list to a value map'
+);
+
+assert.deepStrictEqual(
+  envMapToList({
+    BP_MAVEN_BUILD_ARGUMENTS: 'clean package -pl service-a -am',
+    BP_MAVEN_BUILT_MODULE: 'service-a',
+    BP_MAVEN_BUILT_ARTIFACT: 'service-a/target/app.jar',
+    BUILD_MAVEN_BUILT_MODULE: 'service-a',
+    BUILD_MAVEN_BUILT_ARTIFACT: 'service-a/target/app.jar',
+    CUSTOM_RUNTIME: 'keep'
+  }),
+  [
+    {
+      name: 'BP_MAVEN_BUILD_ARGUMENTS',
+      value: 'clean package -pl service-a -am'
+    },
+    { name: 'BP_MAVEN_BUILT_MODULE', value: 'service-a' },
+    {
+      name: 'BP_MAVEN_BUILT_ARTIFACT',
+      value: 'service-a/target/app.jar'
+    },
+    { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' },
+    {
+      name: 'BUILD_MAVEN_BUILT_ARTIFACT',
+      value: 'service-a/target/app.jar'
+    },
+    { name: 'CUSTOM_RUNTIME', value: 'keep' }
+  ],
+  'should convert canonical and legacy Maven environment values back to a list'
+);
+
+const existingModuleEnvs = [
+  { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' },
+  {
+    name: 'BUILD_MAVEN_BUILT_ARTIFACT',
+    value: 'service-a/target/service-a.jar'
+  },
+  { name: 'BUILD_NO_CACHE', value: 'True' },
+  { name: 'BUILD_PROCFILE', value: 'web: java -jar old.jar' },
+  { name: 'CUSTOM_RUNTIME', value: 'keep' }
+];
+const mergedModuleEnvs = mergeModuleBuildEnvs(
+  existingModuleEnvs,
+  {
+    BP_MAVEN_BUILD_ARGUMENTS: 'clean package -pl service-a -am',
+    BP_MAVEN_BUILT_MODULE: 'service-a',
+    BP_MAVEN_BUILT_ARTIFACT: 'service-a/target/service-a.jar',
+    BUILD_NO_CACHE: false,
+    BUILD_PROCFILE: '   ',
+    JAVA_START_MODE: 'default',
+    cnb_version_policy: { java: { jdk: {} } },
+    runtime_info: { ignored: true }
+  }
+);
+const mergedModuleEnvMap = envListToMap(mergedModuleEnvs);
+
+assert.deepStrictEqual(
+  mergedModuleEnvMap,
+  {
+    CUSTOM_RUNTIME: 'keep',
+    BP_MAVEN_BUILD_ARGUMENTS: 'clean package -pl service-a -am',
+    BP_MAVEN_BUILT_MODULE: 'service-a',
+    BP_MAVEN_BUILT_ARTIFACT: 'service-a/target/service-a.jar'
+  },
+  'should preserve unrelated envs and canonical auto-detected module values while removing superseded legacy aliases'
+);
+
+assert.deepStrictEqual(
+  envListToMap(
+    mergeModuleBuildEnvs(
+      [
+        { name: 'BUILD_MAVEN_CUSTOM_GOALS', value: 'clean install' },
+        { name: 'BUILD_MAVEN_CUSTOM_OPTS', value: '-DskipTests' },
+        { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' },
+        {
+          name: 'BUILD_MAVEN_BUILT_ARTIFACT',
+          value: 'service-a/target/service-a.jar'
+        },
+        { name: 'CUSTOM_RUNTIME', value: 'keep' }
+      ],
+      {
+        BP_MAVEN_BUILD_ARGUMENTS: '',
+        BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS: '',
+        BP_MAVEN_BUILT_MODULE: '',
+        BP_MAVEN_BUILT_ARTIFACT: ''
+      }
+    )
+  ),
+  {
+    CUSTOM_RUNTIME: 'keep',
+    BP_MAVEN_BUILD_ARGUMENTS: '',
+    BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS: '',
+    BP_MAVEN_BUILT_MODULE: '',
+    BP_MAVEN_BUILT_ARTIFACT: ''
+  },
+  'should remove legacy Maven aliases when canonical form fields are explicitly cleared'
+);
+
+assert.deepStrictEqual(
+  envListToMap(
+    mergeModuleBuildEnvs(
+      [
+        { name: 'BUILD_MAVEN_CUSTOM_GOALS', value: 'clean install' },
+        { name: 'BUILD_MAVEN_CUSTOM_OPTS', value: '-DskipTests' },
+        { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' },
+        {
+          name: 'BUILD_MAVEN_BUILT_ARTIFACT',
+          value: 'service-a/target/service-a.jar'
+        }
+      ],
+      { BP_JVM_VERSION: '17' }
+    )
+  ),
+  {
+    BUILD_MAVEN_CUSTOM_GOALS: 'clean install',
+    BUILD_MAVEN_CUSTOM_OPTS: '-DskipTests',
+    BUILD_MAVEN_BUILT_MODULE: 'service-a',
+    BUILD_MAVEN_BUILT_ARTIFACT: 'service-a/target/service-a.jar',
+    BP_JVM_VERSION: '17'
+  },
+  'should preserve legacy Maven aliases until their canonical form fields are present'
+);
+
+assert.deepStrictEqual(
+  envListToMap(envMapToList(mergedModuleEnvMap)),
+  mergedModuleEnvMap,
+  'should preserve merged module build values across the map/list round trip'
+);
+
+assert.deepStrictEqual(envListToMap(), {}, 'should tolerate a missing env list');
+assert.deepStrictEqual(envMapToList(), [], 'should tolerate a missing env map');

--- a/src/components/AppCreateMoreService/index.js
+++ b/src/components/AppCreateMoreService/index.js
@@ -1,35 +1,32 @@
-import React, { PureComponent, Fragment } from "react";
+import React, { PureComponent } from "react";
 import {
   Button,
-  Icon,
-  Card,
   Modal,
-  Row,
-  Col,
   Alert,
   Table,
   Radio,
-  Tabs,
-  Affix,
   Input,
   Form,
-  Tooltip,
-  Checkbox,
   notification
 } from "antd";
 import { connect } from "dva";
 import { formatMessage } from '@/utils/intl';
-import { routerRedux } from "dva/router";
 import globalUtil from "../../utils/global";
-import httpResponseUtil from "../../utils/httpResponse";
 import cookie from "@/utils/cookie";
+import JavaCNBConfig from "../CodeBuildConfig/java-cnb";
 import styles from "./setting.less";
+import moduleHelpers from "./helpers";
 
-const RadioButton = Radio.Button;
-const RadioGroup = Radio.Group;
-const TabPane = Tabs.TabPane;
-const { TextArea } = Input;
-const confirm = Modal.confirm;
+const {
+  MODULE_ROLE_POSSIBLE_DEPENDENCY,
+  envListToMap,
+  getDefaultSelectedKeys,
+  getSelectedModules,
+  mergeModuleBuildEnvs,
+  reconcileSelectedKeys,
+  sortModules
+} = moduleHelpers;
+
 @connect(
   ({ user, appControl, teamControl }) => ({ currUser: user.currentUser }),
   null,
@@ -40,16 +37,14 @@ const confirm = Modal.confirm;
 class BaseInfo extends PureComponent {
   constructor(props) {
     super(props);
+    const memoryList = sortModules(this.props.data);
     this.state = {
       isShow: [true, true],
-      memoryList: this.props.data,
+      memoryList,
       isEdit: false,
-      isIndex: false,
       editData: false,
-      buildValue: "",
-      startValue: "",
-      activeselectedRows: [],
-      activeselectedRowKeys: "",
+      editEnvMap: {},
+      selectedRowKeys: getDefaultSelectedKeys(memoryList),
       language: cookie.get('language') === 'zh-CN' ? true : false,
       archInfo: []
     };
@@ -59,8 +54,30 @@ class BaseInfo extends PureComponent {
   //     return true
   // }
   componentDidMount() {
+    this.submitSelectedModules();
     this.handleArchCpuInfo()
   }
+  componentDidUpdate(prevProps) {
+    if (prevProps.data !== this.props.data) {
+      const memoryList = sortModules(this.props.data);
+      this.setState(
+        previousState => ({
+          memoryList,
+          selectedRowKeys: reconcileSelectedKeys(
+            previousState.memoryList,
+            memoryList,
+            previousState.selectedRowKeys
+          )
+        }),
+        this.submitSelectedModules
+      );
+    }
+  }
+  submitSelectedModules = () => {
+    const { memoryList, selectedRowKeys } = this.state;
+    const selectedRows = getSelectedModules(memoryList, selectedRowKeys);
+    this.props.onSubmit && this.props.onSubmit(selectedRows);
+  };
   handleSubmit = e => {
     const form = this.props.form;
     form.validateFields((err, fieldsValue) => {
@@ -78,74 +95,58 @@ class BaseInfo extends PureComponent {
       },
       callback: res => {
         if (res && res.bean) {
-          this.setState({
-            archInfo: res.list
-          },()=>{
-            const { memoryList, archInfo } = this.state
-            const info = memoryList
-            if(memoryList && memoryList.length > 0 && archInfo && archInfo.length >0){
-              info.map(item => {
-                item.arch = archInfo[0]
-              })
-            }
-            this.setState({
-              memoryList: info
-            })
-          })
+          const archInfo = Array.isArray(res.list) ? res.list : [];
+          this.setState(
+            previousState => ({
+              archInfo,
+              memoryList: archInfo.length
+                ? previousState.memoryList.map(item => ({
+                    ...item,
+                    arch: item.arch || archInfo[0]
+                  }))
+                : previousState.memoryList
+            }),
+            this.submitSelectedModules
+          );
         }
       }
     });
   }
 
   handleEdit = editData => {
-    let buildValue = "";
-    let startValue = "";
-    if (editData && editData.envs && editData.envs.length > 0) {
-      editData.envs.map(item => {
-        item.name == "BUILD_MAVEN_CUSTOM_OPTS" ? (buildValue = item.value) : "";
-        item.name == "BUILD_PROCFILE" ? (startValue = item.value) : "";
-      });
+    if (this.props.cnbVersionPolicyLoading) {
+      return;
     }
+    this.props.form.resetFields();
     this.setState({
       isEdit: true,
       editData,
-      buildValue,
-      startValue
+      editEnvMap: envListToMap(editData && editData.envs)
     });
   };
 
   handleOk = () => {
-    const { memoryList, editData } = this.state;
+    const { editData } = this.state;
     const form = this.props.form;
-    let arr = memoryList;
     form.validateFields((err, fieldsValue) => {
       if (err) return;
-      arr.map(item => {
-        if (item.id == editData.id) {
-          item.cname = fieldsValue.cname;
-          item.arch = fieldsValue.arch;
-          const procfileValue = (fieldsValue.PROCFILE || '').trim();
-          let hasProcfile = false;
-          item.envs.map(item => {
-            item.name == "BUILD_MAVEN_CUSTOM_OPTS"
-              ? (item.value = fieldsValue.BUILD_MAVEN_CUSTOM_OPTS)
-              : "";
-            if (item.name == "BUILD_PROCFILE") {
-              hasProcfile = true;
-              item.value = procfileValue;
-            }
-          });
-          if (!hasProcfile && procfileValue) {
-            item.envs.push({ name: "BUILD_PROCFILE", value: procfileValue });
-          }
-          item.envs = item.envs.filter(env => !(env.name == "BUILD_PROCFILE" && !env.value));
-        }
-      });
+      const { cname, arch, ...buildFields } = fieldsValue;
       this.setState(
-        {
-          memoryList: arr
-        },
+        previousState => ({
+          memoryList: previousState.memoryList.map(item => {
+            if (item.id != editData.id) {
+              return item;
+            }
+            return {
+              ...item,
+              cname,
+              arch: typeof arch === 'undefined' ? item.arch : arch,
+              envs: mergeModuleBuildEnvs(item.envs, buildFields)
+            };
+          })
+        }),
         () => {
+          this.submitSelectedModules();
           notification.destroy();
           notification.success({ message: formatMessage({id:'notification.success.edit'}) });
           this.handleCancel();
@@ -155,9 +156,11 @@ class BaseInfo extends PureComponent {
   };
 
   handleCancel = () => {
+    this.props.form.resetFields();
     this.setState({
       isEdit: false,
-      isIndex: false
+      editData: false,
+      editEnvMap: {}
     });
   };
   render() {
@@ -166,7 +169,17 @@ class BaseInfo extends PureComponent {
         title: formatMessage({id:'JavaMaven.name'}),
         dataIndex: "name",
         rowKey: "name",
-        width: "15%"
+        width: "15%",
+        render: (value, record) => (
+          <div>
+            <div>{value}</div>
+            {record.module_role === MODULE_ROLE_POSSIBLE_DEPENDENCY && (
+              <small>
+                {formatMessage({id:'JavaMaven.possible_dependency'})}
+              </small>
+            )}
+          </div>
+        )
       },
       {
         title: formatMessage({id:'JavaMaven.cname'}),
@@ -205,20 +218,16 @@ class BaseInfo extends PureComponent {
 
         render: (val, row, index) => {
           const { archInfo } = this.state
-          let CUSTOM_OPTS = "";
-          let CUSTOM_GOALS = "";
-          let startValue = "";
-          if (val && val.length > 0) {
-            val.map(item => {
-              item.name == "BUILD_MAVEN_CUSTOM_OPTS"
-                ? (CUSTOM_OPTS = item.value)
-                : "";
-              item.name == "BUILD_MAVEN_CUSTOM_GOALS"
-                ? (CUSTOM_GOALS = item.value)
-                : "";
-              item.name == "BUILD_PROCFILE" ? (startValue = item.value) : "";
-            });
-          }
+          const envMap = envListToMap(val);
+          const CUSTOM_OPTS =
+            envMap.BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS ||
+            envMap.BUILD_MAVEN_CUSTOM_OPTS ||
+            "";
+          const CUSTOM_GOALS =
+            envMap.BP_MAVEN_BUILD_ARGUMENTS ||
+            envMap.BUILD_MAVEN_CUSTOM_GOALS ||
+            "";
+          const startValue = envMap.BUILD_PROCFILE || "";
 
           return (
             <div key={index}>
@@ -253,6 +262,8 @@ class BaseInfo extends PureComponent {
         render: (val, index) => {
           return (
             <Button
+              disabled={this.props.cnbVersionPolicyLoading}
+              loading={this.props.cnbVersionPolicyLoading}
               onClick={() => {
                 this.handleEdit(index);
               }}
@@ -265,8 +276,9 @@ class BaseInfo extends PureComponent {
     ];
 
     const rowSelection = {
-      onChange: (selectedRowKeys, selectedRows) => {
-        this.props.onSubmit(selectedRows);
+      selectedRowKeys: this.state.selectedRowKeys,
+      onChange: selectedRowKeys => {
+        this.setState({ selectedRowKeys }, this.submitSelectedModules);
       },
       getCheckboxProps: record => ({
         disabled: record.operation, // Column configuration not to be checked
@@ -274,12 +286,7 @@ class BaseInfo extends PureComponent {
       })
     };
 
-    const { getFieldDecorator, getFieldValue } = this.props.form;
-    const radioStyle = {
-      display: "block",
-      height: "30px",
-      lineHeight: "30px"
-    };
+    const { getFieldDecorator } = this.props.form;
     const formItemLayout = {
       labelCol: {
         xs: {
@@ -316,7 +323,14 @@ class BaseInfo extends PureComponent {
         }
       }
     };
-    const { memoryList, isEdit, editData, buildValue, startValue, language, archInfo } = this.state;
+    const {
+      memoryList,
+      isEdit,
+      editData,
+      editEnvMap,
+      language,
+      archInfo
+    } = this.state;
     const isLanguage = language ? formItemLayout : en_formItemLayout
     return (
       <div>
@@ -326,6 +340,7 @@ class BaseInfo extends PureComponent {
             visible={isEdit}
             onOk={this.handleOk}
             onCancel={this.handleCancel}
+            width={1000}
           >
             <Form.Item {...isLanguage} label={formatMessage({id:'JavaMaven.cname'})}>
               {getFieldDecorator("cname", {
@@ -338,22 +353,12 @@ class BaseInfo extends PureComponent {
                 ]
               })(<Input placeholder="" />)}
             </Form.Item>
-            <Form.Item {...isLanguage} label={formatMessage({id:'JavaMaven.bulid'})}>
-              {getFieldDecorator("BUILD_MAVEN_CUSTOM_OPTS", {
-                initialValue: buildValue && buildValue,
-                rules: [
-                  {
-                    required: true,
-                    message: formatMessage({id:'JavaMaven.bulid_input'})
-                  }
-                ]
-              })(<TextArea placeholder="" />)}
-            </Form.Item>
-            <Form.Item {...isLanguage} label={formatMessage({id:'JavaMaven.start'})}>
-              {getFieldDecorator("PROCFILE", {
-                initialValue: startValue && startValue,
-              })(<TextArea placeholder="" />)}
-            </Form.Item>
+            <JavaCNBConfig
+              languageType="java-maven"
+              envs={editEnvMap}
+              form={this.props.form}
+              cnbVersionPolicy={this.props.cnbVersionPolicy}
+            />
             {archInfo && archInfo.length > 0 &&
               <Form.Item {...isLanguage} label={formatMessage({id:'JavaMaven.arch'})}>
                 {getFieldDecorator("arch", {
@@ -370,7 +375,7 @@ class BaseInfo extends PureComponent {
         )}
         <Table
           rowSelection={rowSelection}
-          rowKey={(record,index) => index}
+          rowKey="id"
           dataSource={memoryList}
           columns={columns}
           pagination={false}
@@ -412,7 +417,12 @@ export default class Index extends PureComponent {
               message={formatMessage({id:'JavaMaven.Alert'})}
               type="success"
             />
-            <BaseInfo data={data} onSubmit={this.props.onSubmit} />
+            <BaseInfo
+              data={data}
+              onSubmit={this.props.onSubmit}
+              cnbVersionPolicy={this.props.cnbVersionPolicy}
+              cnbVersionPolicyLoading={this.props.cnbVersionPolicyLoading}
+            />
           </div>
         </div>
       </div>

--- a/src/components/CodeBuildConfig/java-cnb/index.js
+++ b/src/components/CodeBuildConfig/java-cnb/index.js
@@ -75,6 +75,7 @@ const hasValue = value => typeof value === 'string' ? value.trim() !== '' : !!va
 class JavaCNBConfig extends PureComponent {
   constructor(props) {
     super(props);
+    this.mounted = false;
     this.state = {
       mavenVisible: false,
       MavenList: [],
@@ -84,9 +85,14 @@ class JavaCNBConfig extends PureComponent {
   }
 
   componentDidMount() {
+    this.mounted = true;
     if (this.isMavenLanguage(this.props.languageType)) {
       this.fetchMavensettings();
     }
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
   }
 
   componentDidUpdate(prevProps) {
@@ -131,7 +137,7 @@ class JavaCNBConfig extends PureComponent {
         onlyname: true
       },
       callback: res => {
-        if (res && res.status_code === 200) {
+        if (this.mounted && res && res.status_code === 200) {
           this.setState({ MavenList: res.list || [] });
         }
       },

--- a/src/locales/en-US/app.js
+++ b/src/locales/en-US/app.js
@@ -519,6 +519,7 @@ const topology = {
 const JavaMaven = {
   'JavaMaven.Alert':'The following is the detected module information of the Maven multi-module project. Please select the module to be built and confirm the construction information',
   'JavaMaven.name':'Module name',
+  'JavaMaven.possible_dependency':'Possibly a dependency module',
   'JavaMaven.cname':'Component name',
   'JavaMaven.packaging':'Package type',
   'JavaMaven.envs':'Build env info',

--- a/src/locales/zh-CN/app.js
+++ b/src/locales/zh-CN/app.js
@@ -529,6 +529,7 @@ const topology = {
 const JavaMaven = {
   'JavaMaven.Alert':'以下为检测出的Maven多模块项目的模块信息, 请选择需要构建的模块, 并确认构建信息',
   'JavaMaven.name':'模块名称',
+  'JavaMaven.possible_dependency':'可能是依赖模块',
   'JavaMaven.cname':'组件名称',
   'JavaMaven.packaging':'包类型',
   'JavaMaven.envs':'构建变量信息',

--- a/src/pages/Create/create-moreService.js
+++ b/src/pages/Create/create-moreService.js
@@ -12,6 +12,9 @@ import { batchOperation } from '../../services/app';
 import globalUtil from '../../utils/global';
 import roleUtil from '../../utils/role';
 import handleAPIError from '../../utils/error';
+import moduleHelpers from '../../components/AppCreateMoreService/helpers';
+
+const { normalizeDetectedModules } = moduleHelpers;
 
 @connect(
   ({ teamControl }) => ({
@@ -30,11 +33,14 @@ export default class Index extends PureComponent {
       JavaMavenData: [],
       is_deploy: true,
       deleteLoading: false,
-      buildState: false
+      buildState: false,
+      cnbVersionPolicy: {},
+      cnbVersionPolicyLoading: true
     };
   }
   componentDidMount() {
     this.getMultipleModulesInfo();
+    this.loadBuildSourceInfo();
   }
   componentWillUnmount() {
     this.props.dispatch({ type: 'appControl/clearDetail' });
@@ -46,6 +52,26 @@ export default class Index extends PureComponent {
     return this.props.match.params.appAlias;
   }
 
+  loadBuildSourceInfo = () => {
+    this.props.dispatch({
+      type: 'appControl/getAppBuidSource',
+      payload: {
+        team_name: globalUtil.getCurrTeamName(),
+        service_alias: this.getAppAlias()
+      },
+      callback: res => {
+        this.setState({
+          cnbVersionPolicy: (res && res.bean && res.bean.cnb_version_policy) || {},
+          cnbVersionPolicyLoading: false
+        });
+      },
+      handleError: err => {
+        this.setState({ cnbVersionPolicyLoading: false });
+        handleAPIError(err);
+      }
+    });
+  };
+
   getMultipleModulesInfo = () => {
     this.props.dispatch({
       type: 'appControl/getMultipleModulesInfo',
@@ -56,7 +82,7 @@ export default class Index extends PureComponent {
       callback: res => {
         if (res && res.status_code === 200) {
           this.setState({
-            data: res.list
+            data: normalizeDetectedModules(res.list)
           });
         }
       },
@@ -200,17 +226,12 @@ export default class Index extends PureComponent {
       is_deploy,
       buildState,
       showDelete,
-      deleteLoading
+      deleteLoading,
+      cnbVersionPolicy,
+      cnbVersionPolicyLoading
       // appPermissions: { isDelete }
     } = this.state;
     const isDelete = true;
-    const arr = data;
-    if (arr && arr.length > 0) {
-      arr.map((item, index) => {
-        arr[index].index = index;
-      });
-    }
-
     return (
       <>
         <PageHeaderLayout
@@ -226,7 +247,9 @@ export default class Index extends PureComponent {
           >
             {data && data.length > 0 && (
               <AppCreateMoreService
-                data={arr}
+                data={data}
+                cnbVersionPolicy={cnbVersionPolicy}
+                cnbVersionPolicyLoading={cnbVersionPolicyLoading}
                 onSubmit={JavaMavenData => {
                   this.setState({
                     JavaMavenData


### PR DESCRIPTION
## Summary

- sort runnable Maven modules first and select them by default, while keeping a select-all fallback for older detection responses
- label likely dependency modules and keep them unselected when runnable modules are known
- reuse the existing Java Maven CNB configuration form for module editing
- load the existing CNB JDK policy and clean superseded legacy Maven aliases on save

## Verification

- AppCreateMoreService helper tests passed
- build environment helper tests passed
- yarn build passed with zero warnings
- git diff --check passed

## Companion PRs

- Core: https://github.com/goodrain/rainbond/pull/2689
- Console: https://github.com/goodrain/rainbond-console/pull/2119