### PR TITLE
refactor: simplify Maven multi-module setup

### DIFF
--- a/src/components/AppCreateMoreService/helpers.js
+++ b/src/components/AppCreateMoreService/helpers.js
@@ -1,58 +1,104 @@
 const {
-  mergeRuntimeBuildEnvs
-} = require('../CodeBuildConfig/buildEnvHelpers');
+  resolveCnbPolicyVersion
+} = require('../CodeBuildConfig/cnbVersionPolicy');
 
-const MODULE_ROLE_RUNNABLE = 'runnable';
-const MODULE_ROLE_POSSIBLE_DEPENDENCY = 'possible_dependency';
-const MAVEN_CANONICAL_LEGACY_ALIASES = {
-  BP_MAVEN_BUILD_ARGUMENTS: 'BUILD_MAVEN_CUSTOM_GOALS',
-  BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS: 'BUILD_MAVEN_CUSTOM_OPTS',
-  BP_MAVEN_BUILT_MODULE: 'BUILD_MAVEN_BUILT_MODULE',
-  BP_MAVEN_BUILT_ARTIFACT: 'BUILD_MAVEN_BUILT_ARTIFACT'
+const BUILD_MODULE_ENV = 'BP_MAVEN_BUILT_MODULE';
+const LEGACY_BUILD_MODULE_ENV = 'BUILD_MAVEN_BUILT_MODULE';
+const MAX_K8S_COMPONENT_NAME_LENGTH = 16;
+
+const envListToMap = (envs = []) =>
+  (Array.isArray(envs) ? envs : []).reduce((envMap, env) => {
+    if (env && env.name) {
+      envMap[env.name] = env.value;
+    }
+    return envMap;
+  }, {});
+
+const getBuildModule = (module = {}) => {
+  const envMap = envListToMap(module && module.envs);
+  const candidates = [
+    envMap[BUILD_MODULE_ENV],
+    envMap[LEGACY_BUILD_MODULE_ENV],
+    module && module.name
+  ];
+  for (let index = 0; index < candidates.length; index += 1) {
+    const value = String(candidates[index] || '').trim();
+    if (value) {
+      return value;
+    }
+  }
+  return '';
 };
 
-const roleRank = role => {
-  if (role === MODULE_ROLE_RUNNABLE) {
-    return 0;
+const normalizeK8sName = value => {
+  const segments = String(value || '').split('/').filter(Boolean);
+  const leafName = segments.length ? segments[segments.length - 1] : '';
+  let normalized = leafName
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (!normalized) {
+    normalized = 'component';
+  } else if (!/^[a-z]/.test(normalized)) {
+    normalized = `component-${normalized}`;
   }
-  if (role === MODULE_ROLE_POSSIBLE_DEPENDENCY) {
-    return 2;
-  }
-  return 1;
+
+  return normalized
+    .slice(0, MAX_K8S_COMPONENT_NAME_LENGTH)
+    .replace(/-+$/g, '') || 'component';
 };
 
-const cloneModule = module => {
-  if (!module || typeof module !== 'object') {
-    return module;
+const buildUniqueK8sName = (module, usedNames) => {
+  const sourceName =
+    (module && module.k8s_component_name) || getBuildModule(module) ||
+    (module && module.cname);
+  const baseName = normalizeK8sName(sourceName);
+  let candidate = baseName;
+  let suffixIndex = 2;
+
+  while (usedNames.has(candidate)) {
+    const suffix = `-${suffixIndex}`;
+    const prefix = baseName
+      .slice(0, MAX_K8S_COMPONENT_NAME_LENGTH - suffix.length)
+      .replace(/-+$/g, '');
+    candidate = `${prefix || 'component'}${suffix}`;
+    suffixIndex += 1;
   }
-  return {
-    ...module,
-    envs: Array.isArray(module.envs)
-      ? module.envs.map(env =>
-          env && typeof env === 'object' ? { ...env } : env
-        )
-      : module.envs
-  };
+
+  usedNames.add(candidate);
+  return candidate;
 };
 
-const sortModules = (modules = []) =>
-  (Array.isArray(modules) ? modules : [])
-    .map((module, index) => ({ module: cloneModule(module), index }))
-    .sort((left, right) => {
-      const rankDiff =
-        roleRank(left.module && left.module.module_role) -
-        roleRank(right.module && right.module.module_role);
-      return rankDiff || left.index - right.index;
-    })
-    .map(item => item.module);
+const normalizeDetectedModules = (modules = []) => {
+  const usedNames = new Set();
+  return (Array.isArray(modules) ? modules : []).map((module, index) => {
+    const normalizedModule = module && typeof module === 'object' ? module : {};
+    const buildModule = getBuildModule(normalizedModule);
+    const moduleWithoutRole = { ...normalizedModule };
+    delete moduleWithoutRole.module_role;
+    return {
+      ...moduleWithoutRole,
+      index,
+      k8s_component_name: buildUniqueK8sName(normalizedModule, usedNames),
+      envs: [{ name: BUILD_MODULE_ENV, value: buildModule }]
+    };
+  });
+};
 
-const getDefaultSelectedKeys = (modules = []) => {
-  const moduleList = Array.isArray(modules) ? modules : [];
-  const runnableModules = moduleList.filter(
-    module => module && module.module_role === MODULE_ROLE_RUNNABLE
+const getDefaultSelectedKeys = () => [];
+
+const isK8sNameDuplicate = (modules = [], value = '', excludedId) => {
+  const targetName = String(value || '').trim();
+  if (!targetName) {
+    return false;
+  }
+  return (Array.isArray(modules) ? modules : []).some(module =>
+    module &&
+    module.id !== excludedId &&
+    String(module.k8s_component_name || '').trim() === targetName
   );
-  const selectedModules = runnableModules.length ? runnableModules : moduleList;
-  return selectedModules.map(module => module && module.id);
 };
 
 const getSelectedModules = (modules = [], selectedKeys = []) => {
@@ -88,7 +134,7 @@ const reconcileSelectedKeys = (
   selectedKeys = []
 ) => {
   if (!hasSameModuleIds(previousModules, nextModules)) {
-    return getDefaultSelectedKeys(nextModules);
+    return getDefaultSelectedKeys();
   }
   const nextIds = nextModules.map(module => module && module.id);
   return (Array.isArray(selectedKeys) ? selectedKeys : []).filter(
@@ -96,53 +142,25 @@ const reconcileSelectedKeys = (
   );
 };
 
-const envListToMap = (envs = []) =>
-  (Array.isArray(envs) ? envs : []).reduce((envMap, env) => {
-    if (env && env.name) {
-      envMap[env.name] = env.value;
-    }
-    return envMap;
-  }, {});
-
-const envMapToList = (envMap = {}) => {
-  if (!envMap || typeof envMap !== 'object' || Array.isArray(envMap)) {
-    return [];
-  }
-  return Object.keys(envMap).map(name => ({ name, value: envMap[name] }));
-};
-
-const normalizeDetectedModules = (modules = []) =>
-  (Array.isArray(modules) ? modules : []).map((module, index) => ({
-    ...(module || {}),
-    index
-  }));
-
-const mergeModuleBuildEnvs = (existingEnvs = [], fieldsValue = {}) => {
-  const canonicalFields =
-    fieldsValue && typeof fieldsValue === 'object' ? fieldsValue : {};
-  const mergedEnvMap = mergeRuntimeBuildEnvs(
-    envListToMap(existingEnvs),
-    canonicalFields
+const getDefaultOpenJDKVersion = (policy = {}) => {
+  const runtimePolicy =
+    policy && policy.java && policy.java.jdk ? policy.java.jdk : {};
+  return resolveCnbPolicyVersion(
+    'java',
+    runtimePolicy.visible_versions || [],
+    '',
+    runtimePolicy.default_version || ''
   );
-
-  Object.keys(MAVEN_CANONICAL_LEGACY_ALIASES).forEach(canonicalName => {
-    if (Object.prototype.hasOwnProperty.call(canonicalFields, canonicalName)) {
-      delete mergedEnvMap[MAVEN_CANONICAL_LEGACY_ALIASES[canonicalName]];
-    }
-  });
-
-  return envMapToList(mergedEnvMap);
 };
 
 module.exports = {
-  MODULE_ROLE_POSSIBLE_DEPENDENCY,
-  MODULE_ROLE_RUNNABLE,
+  BUILD_MODULE_ENV,
   envListToMap,
-  envMapToList,
+  getBuildModule,
+  getDefaultOpenJDKVersion,
   getDefaultSelectedKeys,
   getSelectedModules,
-  mergeModuleBuildEnvs,
+  isK8sNameDuplicate,
   normalizeDetectedModules,
-  reconcileSelectedKeys,
-  sortModules
+  reconcileSelectedKeys
 };

--- a/src/components/AppCreateMoreService/helpers.node.test.js
+++ b/src/components/AppCreateMoreService/helpers.node.test.js
@@ -1,120 +1,123 @@
 const assert = require('assert');
 const {
   envListToMap,
-  envMapToList,
+  getBuildModule,
+  getDefaultOpenJDKVersion,
   getDefaultSelectedKeys,
   getSelectedModules,
-  mergeModuleBuildEnvs,
+  isK8sNameDuplicate,
   normalizeDetectedModules,
-  reconcileSelectedKeys,
-  sortModules
+  reconcileSelectedKeys
 } = require('./helpers');
 
-const detectedModules = [{ id: 'module-a' }, { id: 'module-b', index: 99 }];
-const normalizedDetectedModules = normalizeDetectedModules(detectedModules);
-
-assert.deepStrictEqual(
-  normalizedDetectedModules,
-  [{ id: 'module-a', index: 0 }, { id: 'module-b', index: 1 }],
-  'should defensively normalize detected modules and assign stable display indexes'
-);
-assert.notStrictEqual(
-  normalizedDetectedModules[0],
-  detectedModules[0],
-  'should clone detected module rows instead of mutating API response objects'
-);
-assert.deepStrictEqual(
-  detectedModules,
-  [{ id: 'module-a' }, { id: 'module-b', index: 99 }],
-  'should leave the API response list untouched'
-);
-assert.deepStrictEqual(
-  normalizeDetectedModules(null),
-  [],
-  'should normalize a missing detected module list to an empty array'
-);
-
-const modules = [
-  { id: 'unknown-a' },
-  { id: 'dep-a', module_role: 'possible_dependency' },
-  { id: 'run-a', module_role: 'runnable' },
-  { id: 'unknown-b', module_role: 'custom' },
-  { id: 'run-b', module_role: 'runnable' },
-  { id: 'dep-b', module_role: 'possible_dependency' }
-];
-
-assert.deepStrictEqual(
-  sortModules(modules).map(item => item.id),
-  ['run-a', 'run-b', 'unknown-a', 'unknown-b', 'dep-a', 'dep-b'],
-  'should stably sort runnable modules first and possible dependencies last'
-);
-
-assert.deepStrictEqual(
-  modules.map(item => item.id),
-  ['unknown-a', 'dep-a', 'run-a', 'unknown-b', 'run-b', 'dep-b'],
-  'should not mutate the detected module list while sorting'
-);
-
-const modulesWithEnvs = [
+const detectedModules = [
   {
-    id: 'module-with-envs',
-    module_role: 'runnable',
-    envs: [{ name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' }]
+    id: 'module-b',
+    name: 'services/pig-gateway',
+    cname: '网关',
+    module_role: 'possible_dependency',
+    envs: [
+      { name: 'BUILD_MAVEN_CUSTOM_GOALS', value: 'clean install' },
+      { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'services/pig-gateway' },
+      { name: 'BUILD_MAVEN_BUILT_ARTIFACT', value: 'target/app.jar' }
+    ]
+  },
+  {
+    id: 'module-a',
+    name: 'pig-register',
+    cname: 'pig-register',
+    envs: [
+      { name: 'BP_MAVEN_BUILT_MODULE', value: 'pig-register' },
+      { name: 'BP_JVM_VERSION', value: '21' }
+    ]
   }
 ];
-const normalizedModules = sortModules(modulesWithEnvs);
+const normalizedModules = normalizeDetectedModules(detectedModules);
 
+assert.deepStrictEqual(
+  normalizedModules.map(item => item.id),
+  ['module-b', 'module-a'],
+  'should preserve the module order returned by the detection API'
+);
+assert.deepStrictEqual(
+  normalizedModules.map(item => item.index),
+  [0, 1],
+  'should assign stable display indexes without changing order'
+);
+assert.deepStrictEqual(
+  normalizedModules[0].envs,
+  [{ name: 'BP_MAVEN_BUILT_MODULE', value: 'services/pig-gateway' }],
+  'should keep only the canonical build-module environment variable'
+);
+assert.deepStrictEqual(
+  normalizedModules[1].envs,
+  [{ name: 'BP_MAVEN_BUILT_MODULE', value: 'pig-register' }],
+  'should prefer the canonical build-module value when it is present'
+);
+assert.strictEqual(
+  normalizedModules[0].k8s_component_name,
+  'pig-gateway',
+  'should derive a valid English component name from the module leaf name'
+);
+assert.strictEqual(
+  Object.prototype.hasOwnProperty.call(normalizedModules[0], 'module_role'),
+  false,
+  'should remove the obsolete module-role classification from the create payload'
+);
 assert.notStrictEqual(
   normalizedModules[0],
-  modulesWithEnvs[0],
-  'should clone module objects while normalizing detected data'
+  detectedModules[0],
+  'should clone module objects instead of mutating the API response'
 );
-assert.notStrictEqual(
-  normalizedModules[0].envs,
-  modulesWithEnvs[0].envs,
-  'should clone module env arrays while normalizing detected data'
+assert.deepStrictEqual(
+  detectedModules[0].envs,
+  [
+    { name: 'BUILD_MAVEN_CUSTOM_GOALS', value: 'clean install' },
+    { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'services/pig-gateway' },
+    { name: 'BUILD_MAVEN_BUILT_ARTIFACT', value: 'target/app.jar' }
+  ],
+  'should leave the API response environment variables untouched'
 );
-assert.notStrictEqual(
-  normalizedModules[0].envs[0],
-  modulesWithEnvs[0].envs[0],
-  'should clone module env entries while normalizing detected data'
-);
-normalizedModules[0].envs[0].value = 'changed';
-assert.strictEqual(
-  modulesWithEnvs[0].envs[0].value,
-  'service-a',
-  'should keep source module env values untouched after editing normalized data'
-);
+
+const duplicateNames = normalizeDetectedModules([
+  { id: 'one', name: '123_Service_With_A_Very_Long_Name' },
+  { id: 'two', name: '123_Service_With_A_Very_Long_Name' },
+  { id: 'three', name: '中文模块' }
+]).map(item => item.k8s_component_name);
 
 assert.deepStrictEqual(
-  getDefaultSelectedKeys(modules),
-  ['run-a', 'run-b'],
-  'should default-select only runnable modules when any are detected'
+  duplicateNames,
+  ['component-123-se', 'component-123-2', 'component'],
+  'should generate deterministic and unique English names within 16 characters'
 );
-
-const modulesWithoutRunnable = [
-  { id: 'unknown', module_role: 'custom' },
-  { id: 'dep', module_role: 'possible_dependency' }
-];
+duplicateNames.forEach(name => {
+  assert.ok(name.length <= 16, 'generated English names should not exceed 16 characters');
+  assert.ok(
+    /^[a-z]([-a-z0-9]*[a-z0-9])?$/.test(name),
+    'generated English names should satisfy the existing component-name validator'
+  );
+});
 
 assert.deepStrictEqual(
-  getDefaultSelectedKeys(modulesWithoutRunnable),
-  ['unknown', 'dep'],
-  'should select every module when no runnable module is detected'
-);
-
-assert.deepStrictEqual(
-  getDefaultSelectedKeys([]),
+  getDefaultSelectedKeys(normalizedModules),
   [],
-  'should handle an empty module list'
+  'should not select any detected module by default'
 );
-
+assert.strictEqual(
+  isK8sNameDuplicate(normalizedModules, 'pig-register', 'module-b'),
+  true,
+  'should reject an English component name already used by another module'
+);
+assert.strictEqual(
+  isK8sNameDuplicate(normalizedModules, 'pig-register', 'module-a'),
+  false,
+  'should ignore the module currently being edited during duplicate checks'
+);
 assert.deepStrictEqual(
-  getSelectedModules(modules, ['run-b', 'unknown-a']),
-  [modules[0], modules[4]],
-  'should derive selected modules in the current display order'
+  getSelectedModules(normalizedModules, ['module-a']),
+  [normalizedModules[1]],
+  'should derive selected modules in the original display order'
 );
-
 assert.deepStrictEqual(
   reconcileSelectedKeys(
     [{ id: 'module-a' }, { id: 'module-b' }],
@@ -122,160 +125,51 @@ assert.deepStrictEqual(
     ['module-a', 'missing']
   ),
   ['module-a'],
-  'should preserve and crop controlled selection when the dataset is unchanged'
+  'should preserve and crop controlled selection for the same dataset'
 );
-
 assert.deepStrictEqual(
   reconcileSelectedKeys(
     [{ id: 'old-module' }],
-    [
-      { id: 'new-dependency', module_role: 'possible_dependency' },
-      { id: 'new-runnable', module_role: 'runnable' }
-    ],
+    [{ id: 'new-module' }],
     ['old-module']
   ),
-  ['new-runnable'],
-  'should apply runnable defaults when a genuinely new dataset arrives'
+  [],
+  'should keep a new dataset unselected by default'
 );
 
-assert.deepStrictEqual(
-  envListToMap([
-    { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' },
-    { name: 'CUSTOM_RUNTIME', value: 'keep' }
-  ]),
-  {
-    BUILD_MAVEN_BUILT_MODULE: 'service-a',
-    CUSTOM_RUNTIME: 'keep'
-  },
-  'should convert an environment variable list to a value map'
+assert.strictEqual(
+  getBuildModule({ name: 'fallback-module', envs: [] }),
+  'fallback-module',
+  'should use the detected module name when no build-module env is present'
 );
-
-assert.deepStrictEqual(
-  envMapToList({
-    BP_MAVEN_BUILD_ARGUMENTS: 'clean package -pl service-a -am',
-    BP_MAVEN_BUILT_MODULE: 'service-a',
-    BP_MAVEN_BUILT_ARTIFACT: 'service-a/target/app.jar',
-    BUILD_MAVEN_BUILT_MODULE: 'service-a',
-    BUILD_MAVEN_BUILT_ARTIFACT: 'service-a/target/app.jar',
-    CUSTOM_RUNTIME: 'keep'
+assert.strictEqual(
+  getBuildModule({
+    name: 'fallback-module',
+    envs: [
+      { name: 'BP_MAVEN_BUILT_MODULE', value: '   ' },
+      { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'legacy-module' }
+    ]
   }),
-  [
-    {
-      name: 'BP_MAVEN_BUILD_ARGUMENTS',
-      value: 'clean package -pl service-a -am'
-    },
-    { name: 'BP_MAVEN_BUILT_MODULE', value: 'service-a' },
-    {
-      name: 'BP_MAVEN_BUILT_ARTIFACT',
-      value: 'service-a/target/app.jar'
-    },
-    { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' },
-    {
-      name: 'BUILD_MAVEN_BUILT_ARTIFACT',
-      value: 'service-a/target/app.jar'
-    },
-    { name: 'CUSTOM_RUNTIME', value: 'keep' }
-  ],
-  'should convert canonical and legacy Maven environment values back to a list'
+  'legacy-module',
+  'should ignore an empty canonical value when a legacy module value is available'
 );
-
-const existingModuleEnvs = [
-  { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' },
-  {
-    name: 'BUILD_MAVEN_BUILT_ARTIFACT',
-    value: 'service-a/target/service-a.jar'
-  },
-  { name: 'BUILD_NO_CACHE', value: 'True' },
-  { name: 'BUILD_PROCFILE', value: 'web: java -jar old.jar' },
-  { name: 'CUSTOM_RUNTIME', value: 'keep' }
-];
-const mergedModuleEnvs = mergeModuleBuildEnvs(
-  existingModuleEnvs,
-  {
-    BP_MAVEN_BUILD_ARGUMENTS: 'clean package -pl service-a -am',
-    BP_MAVEN_BUILT_MODULE: 'service-a',
-    BP_MAVEN_BUILT_ARTIFACT: 'service-a/target/service-a.jar',
-    BUILD_NO_CACHE: false,
-    BUILD_PROCFILE: '   ',
-    JAVA_START_MODE: 'default',
-    cnb_version_policy: { java: { jdk: {} } },
-    runtime_info: { ignored: true }
-  }
-);
-const mergedModuleEnvMap = envListToMap(mergedModuleEnvs);
-
 assert.deepStrictEqual(
-  mergedModuleEnvMap,
-  {
-    CUSTOM_RUNTIME: 'keep',
-    BP_MAVEN_BUILD_ARGUMENTS: 'clean package -pl service-a -am',
-    BP_MAVEN_BUILT_MODULE: 'service-a',
-    BP_MAVEN_BUILT_ARTIFACT: 'service-a/target/service-a.jar'
-  },
-  'should preserve unrelated envs and canonical auto-detected module values while removing superseded legacy aliases'
+  envListToMap(normalizedModules[0].envs),
+  { BP_MAVEN_BUILT_MODULE: 'services/pig-gateway' },
+  'should expose normalized environments to the read-only summary'
 );
-
-assert.deepStrictEqual(
-  envListToMap(
-    mergeModuleBuildEnvs(
-      [
-        { name: 'BUILD_MAVEN_CUSTOM_GOALS', value: 'clean install' },
-        { name: 'BUILD_MAVEN_CUSTOM_OPTS', value: '-DskipTests' },
-        { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' },
-        {
-          name: 'BUILD_MAVEN_BUILT_ARTIFACT',
-          value: 'service-a/target/service-a.jar'
-        },
-        { name: 'CUSTOM_RUNTIME', value: 'keep' }
-      ],
-      {
-        BP_MAVEN_BUILD_ARGUMENTS: '',
-        BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS: '',
-        BP_MAVEN_BUILT_MODULE: '',
-        BP_MAVEN_BUILT_ARTIFACT: ''
+assert.strictEqual(
+  getDefaultOpenJDKVersion({
+    java: {
+      jdk: {
+        visible_versions: ['11', '17', '21'],
+        default_version: '17.0.12'
       }
-    )
-  ),
-  {
-    CUSTOM_RUNTIME: 'keep',
-    BP_MAVEN_BUILD_ARGUMENTS: '',
-    BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS: '',
-    BP_MAVEN_BUILT_MODULE: '',
-    BP_MAVEN_BUILT_ARTIFACT: ''
-  },
-  'should remove legacy Maven aliases when canonical form fields are explicitly cleared'
+    }
+  }),
+  '17',
+  'should resolve the displayed OpenJDK version from the existing CNB policy'
 );
 
-assert.deepStrictEqual(
-  envListToMap(
-    mergeModuleBuildEnvs(
-      [
-        { name: 'BUILD_MAVEN_CUSTOM_GOALS', value: 'clean install' },
-        { name: 'BUILD_MAVEN_CUSTOM_OPTS', value: '-DskipTests' },
-        { name: 'BUILD_MAVEN_BUILT_MODULE', value: 'service-a' },
-        {
-          name: 'BUILD_MAVEN_BUILT_ARTIFACT',
-          value: 'service-a/target/service-a.jar'
-        }
-      ],
-      { BP_JVM_VERSION: '17' }
-    )
-  ),
-  {
-    BUILD_MAVEN_CUSTOM_GOALS: 'clean install',
-    BUILD_MAVEN_CUSTOM_OPTS: '-DskipTests',
-    BUILD_MAVEN_BUILT_MODULE: 'service-a',
-    BUILD_MAVEN_BUILT_ARTIFACT: 'service-a/target/service-a.jar',
-    BP_JVM_VERSION: '17'
-  },
-  'should preserve legacy Maven aliases until their canonical form fields are present'
-);
-
-assert.deepStrictEqual(
-  envListToMap(envMapToList(mergedModuleEnvMap)),
-  mergedModuleEnvMap,
-  'should preserve merged module build values across the map/list round trip'
-);
-
+assert.deepStrictEqual(normalizeDetectedModules(null), [], 'should tolerate missing module data');
 assert.deepStrictEqual(envListToMap(), {}, 'should tolerate a missing env list');
-assert.deepStrictEqual(envMapToList(), [], 'should tolerate a missing env map');

--- a/src/components/AppCreateMoreService/index.js
+++ b/src/components/AppCreateMoreService/index.js
@@ -7,24 +7,31 @@ import {
   Radio,
   Input,
   Form,
-  notification
+  notification,
+  Icon,
+  Tooltip
 } from "antd";
 import { connect } from "dva";
 import { formatMessage } from '@/utils/intl';
 import globalUtil from "../../utils/global";
+import handleAPIError from "../../utils/error";
 import cookie from "@/utils/cookie";
-import JavaCNBConfig from "../CodeBuildConfig/java-cnb";
+import {
+  getArchRules,
+  getK8sComponentNameRules,
+  getServiceNameRules
+} from "../CodeJwarForm/validations";
 import styles from "./setting.less";
 import moduleHelpers from "./helpers";
 
 const {
-  MODULE_ROLE_POSSIBLE_DEPENDENCY,
   envListToMap,
+  getDefaultOpenJDKVersion,
   getDefaultSelectedKeys,
   getSelectedModules,
-  mergeModuleBuildEnvs,
-  reconcileSelectedKeys,
-  sortModules
+  isK8sNameDuplicate,
+  normalizeDetectedModules,
+  reconcileSelectedKeys
 } = moduleHelpers;
 
 @connect(
@@ -37,16 +44,16 @@ const {
 class BaseInfo extends PureComponent {
   constructor(props) {
     super(props);
-    const memoryList = sortModules(this.props.data);
+    this.mounted = false;
+    const memoryList = normalizeDetectedModules(this.props.data);
     this.state = {
-      isShow: [true, true],
       memoryList,
       isEdit: false,
       editData: false,
-      editEnvMap: {},
       selectedRowKeys: getDefaultSelectedKeys(memoryList),
       language: cookie.get('language') === 'zh-CN' ? true : false,
-      archInfo: []
+      archInfo: [],
+      archInfoLoading: true
     };
   }
 
@@ -54,12 +61,16 @@ class BaseInfo extends PureComponent {
   //     return true
   // }
   componentDidMount() {
+    this.mounted = true;
     this.submitSelectedModules();
     this.handleArchCpuInfo()
   }
+  componentWillUnmount() {
+    this.mounted = false;
+  }
   componentDidUpdate(prevProps) {
     if (prevProps.data !== this.props.data) {
-      const memoryList = sortModules(this.props.data);
+      const memoryList = normalizeDetectedModules(this.props.data);
       this.setState(
         previousState => ({
           memoryList,
@@ -74,16 +85,12 @@ class BaseInfo extends PureComponent {
     }
   }
   submitSelectedModules = () => {
+    if (!this.mounted) {
+      return;
+    }
     const { memoryList, selectedRowKeys } = this.state;
     const selectedRows = getSelectedModules(memoryList, selectedRowKeys);
     this.props.onSubmit && this.props.onSubmit(selectedRows);
-  };
-  handleSubmit = e => {
-    const form = this.props.form;
-    form.validateFields((err, fieldsValue) => {
-      if (err) return;
-      this.props.onSubmit && this.props.onSubmit(fieldsValue);
-    });
   };
   handleArchCpuInfo = () => {
     const { dispatch } = this.props;
@@ -94,43 +101,65 @@ class BaseInfo extends PureComponent {
         team_name: globalUtil.getCurrTeamName()
       },
       callback: res => {
-        if (res && res.bean) {
-          const archInfo = Array.isArray(res.list) ? res.list : [];
-          this.setState(
-            previousState => ({
-              archInfo,
-              memoryList: archInfo.length
-                ? previousState.memoryList.map(item => ({
-                    ...item,
-                    arch: item.arch || archInfo[0]
-                  }))
-                : previousState.memoryList
-            }),
-            this.submitSelectedModules
-          );
+        if (!this.mounted) {
+          return;
         }
+        const archInfo = res && res.bean && Array.isArray(res.list)
+          ? res.list
+          : [];
+        this.setState(
+          previousState => ({
+            archInfo,
+            archInfoLoading: false,
+            memoryList: archInfo.length
+              ? previousState.memoryList.map(item => ({
+                  ...item,
+                  arch: item.arch || archInfo[0]
+                }))
+              : previousState.memoryList
+          }),
+          this.submitSelectedModules
+        );
+      },
+      handleError: err => {
+        if (!this.mounted) {
+          return;
+        }
+        this.setState({ archInfoLoading: false });
+        handleAPIError(err);
       }
     });
   }
 
   handleEdit = editData => {
-    if (this.props.cnbVersionPolicyLoading) {
+    const { archInfo, archInfoLoading } = this.state;
+    if (archInfoLoading || !(editData.arch || archInfo.length)) {
       return;
     }
     this.props.form.resetFields();
     this.setState({
       isEdit: true,
-      editData,
-      editEnvMap: envListToMap(editData && editData.envs)
+      editData
     });
   };
 
   handleOk = () => {
-    const { editData } = this.state;
+    const { editData, memoryList } = this.state;
     const form = this.props.form;
     form.validateFields((err, fieldsValue) => {
       if (err) return;
-      const { cname, arch, ...buildFields } = fieldsValue;
+      const { cname, k8s_component_name, arch } = fieldsValue;
+      if (isK8sNameDuplicate(memoryList, k8s_component_name, editData.id)) {
+        form.setFields({
+          k8s_component_name: {
+            value: k8s_component_name,
+            errors: [
+              new Error(formatMessage({id:'JavaMaven.k8s_name_duplicate'}))
+            ]
+          }
+        });
+        return;
+      }
       this.setState(
         previousState => ({
           memoryList: previousState.memoryList.map(item => {
@@ -140,8 +169,8 @@ class BaseInfo extends PureComponent {
             return {
               ...item,
               cname,
-              arch: typeof arch === 'undefined' ? item.arch : arch,
-              envs: mergeModuleBuildEnvs(item.envs, buildFields)
+              k8s_component_name,
+              arch: typeof arch === 'undefined' ? item.arch : arch
             };
           })
         }),
@@ -159,33 +188,31 @@ class BaseInfo extends PureComponent {
     this.props.form.resetFields();
     this.setState({
       isEdit: false,
-      editData: false,
-      editEnvMap: {}
+      editData: false
     });
   };
   render() {
+    const openJDKVersion = this.props.cnbVersionPolicyLoading
+      ? "--"
+      : getDefaultOpenJDKVersion(this.props.cnbVersionPolicy) || "--";
     const columns = [
       {
         title: formatMessage({id:'JavaMaven.name'}),
         dataIndex: "name",
         rowKey: "name",
-        width: "15%",
+        width: "14%"
+      },
+      {
+        title: formatMessage({id:'JavaMaven.component_info'}),
+        dataIndex: "cname",
+        rowKey: "cname",
+        width: "18%",
         render: (value, record) => (
           <div>
             <div>{value}</div>
-            {record.module_role === MODULE_ROLE_POSSIBLE_DEPENDENCY && (
-              <small>
-                {formatMessage({id:'JavaMaven.possible_dependency'})}
-              </small>
-            )}
+            <small>{record.k8s_component_name}</small>
           </div>
         )
-      },
-      {
-        title: formatMessage({id:'JavaMaven.cname'}),
-        dataIndex: "cname",
-        rowKey: "cname",
-        width: "15%"
       },
       {
         title: formatMessage({id:'JavaMaven.packaging'}),
@@ -197,7 +224,7 @@ class BaseInfo extends PureComponent {
         title: formatMessage({id:'JavaMaven.index'}),
         dataIndex: "index",
         rowKey: "index",
-        width: "10%",
+        width: "8%",
 
         render: (val, index) => {
           return (
@@ -211,44 +238,45 @@ class BaseInfo extends PureComponent {
       },
 
       {
-        title: formatMessage({id:'JavaMaven.envs'}),
+        title: (
+          <span>
+            {formatMessage({id:'JavaMaven.source_build_parameters'})}
+            <Tooltip title={formatMessage({id:'JavaMaven.source_build_parameters_tip'})}>
+              <Icon
+                type="exclamation-circle-o"
+                className={styles.sourceBuildTip}
+              />
+            </Tooltip>
+          </span>
+        ),
         dataIndex: "envs",
         rowKey: "envs",
-        width: "45%",
+        width: "44%",
 
         render: (val, row, index) => {
           const { archInfo } = this.state
           const envMap = envListToMap(val);
-          const CUSTOM_OPTS =
-            envMap.BP_MAVEN_ADDITIONAL_BUILD_ARGUMENTS ||
-            envMap.BUILD_MAVEN_CUSTOM_OPTS ||
-            "";
-          const CUSTOM_GOALS =
-            envMap.BP_MAVEN_BUILD_ARGUMENTS ||
-            envMap.BUILD_MAVEN_CUSTOM_GOALS ||
-            "";
-          const startValue = envMap.BUILD_PROCFILE || "";
+          const buildModule = envMap.BP_MAVEN_BUILT_MODULE || row.name || "--";
+          const arch = row.arch || (archInfo && archInfo[0]) || "--";
 
           return (
             <div key={index}>
               <div style={{ display: "flex", marginBottom:6 }}>
-                <p style={{ width: "30%" }}>{formatMessage({ id: 'JavaMaven.OPTS' })}:</p>
-                <div style={{ width: "70%" }}>{CUSTOM_OPTS}</div>
+                <p style={{ width: "30%" }}>{formatMessage({ id: 'JavaMaven.openjdk_version' })}:</p>
+                <div style={{ width: "70%" }}>{openJDKVersion}</div>
               </div>
               <div style={{ display: "flex", marginBottom:6 }}>
                 <p style={{ width: "30%" }}>{formatMessage({ id: 'JavaMaven.GOALS' })}:</p>
-                <div style={{ width: "70%" }}>{CUSTOM_GOALS}</div>
+                <div style={{ width: "70%" }}>clean package</div>
               </div>
               <div style={{ display: "flex", marginBottom:6 }}>
-                <p style={{ width: "30%" }}>{formatMessage({ id: 'JavaMaven.startValue' })}:</p>
-                <div style={{ width: "70%" }}>{startValue}</div>
+                <p style={{ width: "30%" }}>{formatMessage({ id: 'JavaMaven.build_module' })}:</p>
+                <div style={{ width: "70%" }}>{buildModule}</div>
               </div>
-              {(row.arch || (archInfo && archInfo.length >= 1)) &&
-                <div style={{ display: "flex", marginBottom:6 }}>
-                  <p style={{ width: "30%" }}>{formatMessage({id:'JavaMaven.arch'})}:</p>
-                  <div style={{ width: "70%" }}>{row.arch || archInfo[0]}</div>
-                </div>
-              }
+              <div style={{ display: "flex", marginBottom:6 }}>
+                <p style={{ width: "30%" }}>{formatMessage({id:'JavaMaven.arch'})}:</p>
+                <div style={{ width: "70%" }}>{arch}</div>
+              </div>
             </div>
           );
         }
@@ -260,15 +288,18 @@ class BaseInfo extends PureComponent {
         width: "7%",
 
         render: (val, index) => {
+          const { archInfo, archInfoLoading } = this.state;
+          const archUnavailable =
+            archInfoLoading || !(index.arch || archInfo.length);
           return (
             <Button
-              disabled={this.props.cnbVersionPolicyLoading}
-              loading={this.props.cnbVersionPolicyLoading}
+              disabled={archUnavailable}
+              loading={archInfoLoading}
               onClick={() => {
                 this.handleEdit(index);
               }}
             >
-              {formatMessage({id:'teamOther.manage.edit'})}
+              {formatMessage({id:'JavaMaven.edit'})}
             </Button>
           );
         }
@@ -281,7 +312,10 @@ class BaseInfo extends PureComponent {
         this.setState({ selectedRowKeys }, this.submitSelectedModules);
       },
       getCheckboxProps: record => ({
-        disabled: record.operation, // Column configuration not to be checked
+        disabled:
+          record.operation ||
+          this.state.archInfoLoading ||
+          !(record.arch || this.state.archInfo.length),
         operation: record.operation
       })
     };
@@ -327,50 +361,52 @@ class BaseInfo extends PureComponent {
       memoryList,
       isEdit,
       editData,
-      editEnvMap,
       language,
-      archInfo
+      archInfo,
+      archInfoLoading
     } = this.state;
     const isLanguage = language ? formItemLayout : en_formItemLayout
+    const archOptions = archInfo && archInfo.length
+      ? archInfo
+      : editData && editData.arch
+        ? [editData.arch]
+        : [];
     return (
       <div>
         {isEdit && (
           <Modal
-            title={formatMessage({id:'teamOther.manage.edit'})}
+            title={formatMessage({id:'JavaMaven.edit'})}
             visible={isEdit}
             onOk={this.handleOk}
             onCancel={this.handleCancel}
-            width={1000}
+            width={600}
+            confirmLoading={archInfoLoading}
           >
             <Form.Item {...isLanguage} label={formatMessage({id:'JavaMaven.cname'})}>
               {getFieldDecorator("cname", {
                 initialValue: editData && editData.cname,
-                rules: [
-                  {
-                    required: true,
-                    message: formatMessage({id:'JavaMaven.cname_input'})
-                  }
-                ]
-              })(<Input placeholder="" />)}
+                rules: getServiceNameRules()
+              })(<Input placeholder={formatMessage({ id: 'placeholder.component_cname' })} />)}
             </Form.Item>
-            <JavaCNBConfig
-              languageType="java-maven"
-              envs={editEnvMap}
-              form={this.props.form}
-              cnbVersionPolicy={this.props.cnbVersionPolicy}
-            />
-            {archInfo && archInfo.length > 0 &&
-              <Form.Item {...isLanguage} label={formatMessage({id:'JavaMaven.arch'})}>
-                {getFieldDecorator("arch", {
-                  initialValue: editData.arch || (archInfo && archInfo.length > 0 && archInfo[0]),
-                })(
-                  <Radio.Group>
-                    {archInfo.map(item =>{
-                      return <Radio value={item}>{item}</Radio>
-                    })}
-                  </Radio.Group>)}
-              </Form.Item>
-            }
+            <Form.Item
+              {...isLanguage}
+              label={formatMessage({id:'teamAdd.create.form.k8s_component_name'})}
+            >
+              {getFieldDecorator("k8s_component_name", {
+                initialValue: editData && editData.k8s_component_name,
+                rules: getK8sComponentNameRules()
+              })(<Input placeholder={formatMessage({ id: 'placeholder.k8s_component_name' })} />)}
+            </Form.Item>
+            <Form.Item {...isLanguage} label={formatMessage({id:'JavaMaven.arch'})}>
+              {getFieldDecorator("arch", {
+                initialValue: (editData && editData.arch) || archOptions[0],
+                rules: getArchRules()
+              })(
+                <Radio.Group>
+                  {archOptions.map(item => <Radio key={item} value={item}>{item}</Radio>)}
+                </Radio.Group>
+              )}
+            </Form.Item>
           </Modal>
         )}
         <Table

--- a/src/components/AppCreateMoreService/setting.less
+++ b/src/components/AppCreateMoreService/setting.less
@@ -43,6 +43,11 @@
 	min-height: 500px;
 }
 
+.sourceBuildTip {
+	margin-left: 8px;
+	color: @rbd-label-color;
+}
+
 .ant_radio_disabled{
     :global{
         span{
@@ -55,4 +60,3 @@
 
 	
 }
-

--- a/src/locales/en-US/app.js
+++ b/src/locales/en-US/app.js
@@ -519,12 +519,16 @@ const topology = {
 const JavaMaven = {
   'JavaMaven.Alert':'The following is the detected module information of the Maven multi-module project. Please select the module to be built and confirm the construction information',
   'JavaMaven.name':'Module name',
-  'JavaMaven.possible_dependency':'Possibly a dependency module',
   'JavaMaven.cname':'Component name',
+  'JavaMaven.component_info':'Component info',
   'JavaMaven.packaging':'Package type',
   'JavaMaven.envs':'Build env info',
+  'JavaMaven.source_build_parameters':'Source build parameters',
+  'JavaMaven.source_build_parameters_tip':'Only the source build parameters that must be confirmed before creation are shown here. After creating the component, open Build Settings to view and edit the complete configuration.',
+  'JavaMaven.openjdk_version':'OpenJDK version',
   'JavaMaven.OPTS':'Maven build Parameters',
   'JavaMaven.GOALS':'Maven build commands',
+  'JavaMaven.build_module':'Build module',
   'JavaMaven.startValue':'Start Command (Optional)',
   'JavaMaven.index':'Port',
   'JavaMaven.id':'Operation',
@@ -536,6 +540,8 @@ const JavaMaven = {
   'JavaMaven.title':'JavaMaven Multi-module Settings',
   'JavaMaven.Tooltip':'Deselect this option to start without the build.',
   'JavaMaven.arch':'cpu architecture',
+  'JavaMaven.edit':'Edit',
+  'JavaMaven.k8s_name_duplicate':'The English component name must be unique across modules',
 }
 const helmAppInstall = {
   //安装检测主页

--- a/src/locales/zh-CN/app.js
+++ b/src/locales/zh-CN/app.js
@@ -529,12 +529,16 @@ const topology = {
 const JavaMaven = {
   'JavaMaven.Alert':'以下为检测出的Maven多模块项目的模块信息, 请选择需要构建的模块, 并确认构建信息',
   'JavaMaven.name':'模块名称',
-  'JavaMaven.possible_dependency':'可能是依赖模块',
   'JavaMaven.cname':'组件名称',
+  'JavaMaven.component_info':'组件信息',
   'JavaMaven.packaging':'包类型',
   'JavaMaven.envs':'构建变量信息',
+  'JavaMaven.source_build_parameters':'源码构建参数',
+  'JavaMaven.source_build_parameters_tip':'这里只展示创建前需要确认的部分源码构建参数。组件创建后，可进入组件「构建设置」查看和修改完整配置。',
+  'JavaMaven.openjdk_version':'OpenJDK版本',
   'JavaMaven.OPTS':'Maven构建参数',
   'JavaMaven.GOALS':'Maven构建命令',
+  'JavaMaven.build_module':'构建模块',
   'JavaMaven.startValue':'启动命令（可选）',
   'JavaMaven.index':'端口',
   'JavaMaven.id':'操作',
@@ -546,6 +550,8 @@ const JavaMaven = {
   'JavaMaven.title':'JavaMaven多模块设置',
   'JavaMaven.Tooltip':'取消本选项,不构建启动。',
   'JavaMaven.arch':'cpu架构',
+  'JavaMaven.edit':'编辑',
+  'JavaMaven.k8s_name_duplicate':'组件英文名称不能与其他模块重复',
 }
 const helmAppInstall = {
   //安装检测主页

--- a/src/pages/Create/create-moreService.js
+++ b/src/pages/Create/create-moreService.js
@@ -12,9 +12,6 @@ import { batchOperation } from '../../services/app';
 import globalUtil from '../../utils/global';
 import roleUtil from '../../utils/role';
 import handleAPIError from '../../utils/error';
-import moduleHelpers from '../../components/AppCreateMoreService/helpers';
-
-const { normalizeDetectedModules } = moduleHelpers;
 
 @connect(
   ({ teamControl }) => ({
@@ -27,6 +24,7 @@ const { normalizeDetectedModules } = moduleHelpers;
 export default class Index extends PureComponent {
   constructor(props) {
     super(props);
+    this.mounted = false;
     this.state = {
       // appPermissions: this.handlePermissions('queryAppInfo'),
       data: null,
@@ -39,10 +37,12 @@ export default class Index extends PureComponent {
     };
   }
   componentDidMount() {
+    this.mounted = true;
     this.getMultipleModulesInfo();
     this.loadBuildSourceInfo();
   }
   componentWillUnmount() {
+    this.mounted = false;
     this.props.dispatch({ type: 'appControl/clearDetail' });
   }
   getCheck_uuid() {
@@ -60,12 +60,18 @@ export default class Index extends PureComponent {
         service_alias: this.getAppAlias()
       },
       callback: res => {
+        if (!this.mounted) {
+          return;
+        }
         this.setState({
           cnbVersionPolicy: (res && res.bean && res.bean.cnb_version_policy) || {},
           cnbVersionPolicyLoading: false
         });
       },
       handleError: err => {
+        if (!this.mounted) {
+          return;
+        }
         this.setState({ cnbVersionPolicyLoading: false });
         handleAPIError(err);
       }
@@ -80,13 +86,30 @@ export default class Index extends PureComponent {
         check_uuid: this.getCheck_uuid()
       },
       callback: res => {
+        if (!this.mounted) {
+          return;
+        }
         if (res && res.status_code === 200) {
+          const detectedModules = Array.isArray(res.list) ? res.list : [];
           this.setState({
-            data: normalizeDetectedModules(res.list)
+            data: detectedModules.map(module => {
+              const clonedModule = module && typeof module === 'object'
+                ? { ...module }
+                : {};
+              if (Array.isArray(clonedModule.envs)) {
+                clonedModule.envs = clonedModule.envs.map(env =>
+                  env && typeof env === 'object' ? { ...env } : env
+                );
+              }
+              return clonedModule;
+            })
           });
         }
       },
       handleError: err => {
+        if (!this.mounted) {
+          return;
+        }
         handleAPIError(err);
       }
     });


### PR DESCRIPTION
## Summary

- keep detected module order and leave all modules unselected by default
- submit only BP_MAVEN_BUILT_MODULE while showing a four-line read-only build summary
- reduce the edit modal to component name, English name, and CPU architecture
- validate unique English names and guard architecture loading before selection

## Related PRs

- goodrain/rainbond#2690
- goodrain/rainbond-console#2121

## Validation

- AppCreateMoreService helper tests passed
- build environment helper tests passed
- yarn build completed with zero warnings
- git diff --check passed