### PR TITLE
fix: correct platform resource menu filtering

### DIFF
--- a/src/components/GlobalRouter/index.js
+++ b/src/components/GlobalRouter/index.js
@@ -9,6 +9,8 @@ import globalUtil from '../../utils/global';
 import userUtil from '../../utils/user';
 import styles from './index.less';
 
+const { isSourceRoute } = require('./permission');
+
 /**
  * 获取菜单图标
  */
@@ -282,7 +284,7 @@ export default class GlobalRouter extends PureComponent {
     const { currentUser } = this.props;
     const team_name = globalUtil.getCurrTeamName();
 
-    if (item.path?.indexOf('source') > -1) {
+    if (isSourceRoute(item.path)) {
       return currentUser?.is_sys_admin || currentUser?.is_user_enter_amdin;
     }
     if (item.path?.indexOf('finance') > -1) {

--- a/src/components/GlobalRouter/permission.js
+++ b/src/components/GlobalRouter/permission.js
@@ -1,0 +1,12 @@
+function isSourceRoute(path) {
+  if (typeof path !== 'string') {
+    return false;
+  }
+
+  const pathname = path.split(/[?#]/)[0];
+  return pathname.split('/').includes('source');
+}
+
+module.exports = {
+  isSourceRoute
+};

--- a/src/components/GlobalRouter/permission.node.test.js
+++ b/src/components/GlobalRouter/permission.node.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+
+const { isSourceRoute } = require('./permission');
+
+assert.strictEqual(
+  isSourceRoute('/enterprise/eid/region/rainbond/platform-resources'),
+  false,
+  'platform resource routes should not require source-route permissions'
+);
+assert.strictEqual(
+  isSourceRoute('/team/team/region/rainbond/resources'),
+  false,
+  'resource route names should not be treated as source path segments'
+);
+
+assert.strictEqual(isSourceRoute('/team/team/region/rainbond/source'), true);
+assert.strictEqual(isSourceRoute('/team/team/region/rainbond/source/git'), true);
+assert.strictEqual(isSourceRoute('/team/team/region/rainbond/source?type=git'), true);
+assert.strictEqual(isSourceRoute('/team/team/region/rainbond/source-control'), false);
+assert.strictEqual(isSourceRoute(), false);
+
+console.log('global router permission tests passed');


### PR DESCRIPTION
## Summary

- match source-code routes by an exact path segment
- keep platform-resources visible for enterprise administrators
- add regression coverage for source and resource route names

## Verification

- node src/components/GlobalRouter/permission.node.test.js
- node src/components/GlobalRouter/globalRouterScrollbar.node.test.js
- node src/utils/user.node.test.js
- node src/common/enterpriseMenu.node.test.js
- yarn build
- git diff --check origin/v6.9.9-pre...HEAD